### PR TITLE
Added custom world launch file in follow line exercise (Updated README.md accordingly)

### DIFF
--- a/exercises/follow_line/README.md
+++ b/exercises/follow_line/README.md
@@ -3,6 +3,8 @@ The objective of this practice is to perform a PID reactive control capable of f
 
 ## How to execute?
 To launch the infrastructure of this practice, first set up the gazebo sources, then launch the simulator with the appropriate scenario:
+
+
 ```
 source /opt/jderobot/share/jderobot/gazebo/gazebo-setup.sh
 ```
@@ -11,9 +13,27 @@ source /opt/jderobot/share/jderobot/gazebo/gazebo-setup.sh
 source /opt/jderobot/share/jderobot/gazebo/gazebo-assets-setup.sh
 ```
 
+or add them directly to your bashrc to run automatically whenver you open a terminal:
+
 ```
-roslaunch /opt/jderobot/share/jderobot/gazebo/launch/f1_1_simplecircuit.launch world:=/opt/jderobot/share/jderobot/gazebo/worlds/f1_1_simplecircuit.world
+echo 'source /opt/jderobot/share/jderobot/gazebo/gazebo-setup.sh' > ~/.bashrc
 ```
+
+```
+echo 'source /opt/jderobot/share/jderobot/gazebo/gazebo-assets-setup.sh' > ~/.bashrc
+```
+
+```
+source ~/.bashrc
+```
+
+Launch Gazebo with the f1_simple_circuit world through the command 
+
+```
+roslaunch ./launch/simple_line_follower_ros.launch
+```
+
+
 Then you have to execute the academic application, which will incorporate your code:
 ```
 python2 ./follow_line.py follow_line_conf.yml

--- a/exercises/follow_line/launch/simple_line_follower_ros.launch
+++ b/exercises/follow_line/launch/simple_line_follower_ros.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<launch>
+  <include file="/opt/jderobot/share/jderobot/gazebo/launch/f1_1_simplecircuit.launch">
+  </include>
+</launch>


### PR DESCRIPTION
I added a launch file for launching the target world instead of retyping the whole command with the world/launch file path. I also updated the README.md to make it easier to follow and suggested that users add the source commands to their bashrc/profile so they don't repeat it every time . I suggest we add tthe last part in the main readme of the repository.