### PR TITLE
Update broken URL in Installation Guide

### DIFF
--- a/docs/_pages/exercises/Drones/drone_gymkhana.md
+++ b/docs/_pages/exercises/Drones/drone_gymkhana.md
@@ -47,7 +47,7 @@ sudo apt-get install ros-melodic-jderobot-drones
 
 ## How to run the exercise
 
-To launch the exercise, open a terminal window, navigate to the drone_gymkhana exercise folder and execute the following roslaunch command:
+To launch the exercise, open a terminal window, navigate to the [drone_gymkhana exercise folder](https://github.com/JdeRobot/RoboticsAcademy/tree/master/exercises/drone_gymkhana) and execute the following roslaunch command:
 
 ```bash
 roslaunch drone_gymkhana.launch

--- a/docs/_pages/installation.md
+++ b/docs/_pages/installation.md
@@ -220,7 +220,7 @@ Install previous dependencies:
 7. Get FastRTPS and FastCDR
 
     ```bash
-    wget https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-1/eprosima_fastrtps-1-7-1-linux-tar-gz -O eprosima_fastrtps-1-7-1-linux.tar.gz
+    wget https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-dds/eprosima-fast-rtps-1-7-1/eprosima_fastrtps-1-7-1-linux-tar-gz -O eprosima_fastrtps-1-7-1-linux.tar.gz
     tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz eProsima_FastRTPS-1.7.1-Linux/
     tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz requiredcomponents
     tar -xzf requiredcomponents/eProsima_FastCDR-1.0.8-Linux.tar.gz


### PR DESCRIPTION
update "Get FastRTPS and FastCDR" url

https://github.com/eProsima/Fast-RTPS-docs/issues/171

As you can see here, the link has been changed