### PR TITLE
add Connect button on exercises webpages

### DIFF
--- a/exercises/follow_line/web-template/assets/launcher.js
+++ b/exercises/follow_line/web-template/assets/launcher.js
@@ -6,11 +6,12 @@ ws_manager.onopen = function(event){
     ws_manager.send(JSON.stringify({"command": "open", "exercise": exercise}));
 }
 
+//We must receive 2 "Done" messages before we can connect/disconnect
+var rcv_msgs = 0;
 ws_manager.onmessage = function(event){
     console.log(event.data);
+    rcv_msgs += 1;
+    if (rcv_msgs==2){
+        setup_completed=true;
+    }
 }
-
-setTimeout(function(){
-    declare_code(websocket_address);
-    declare_gui(websocket_address);
-}, 10000);

--- a/exercises/follow_line/web-template/assets/main.css
+++ b/exercises/follow_line/web-template/assets/main.css
@@ -104,6 +104,14 @@ margin-bottom: 10px;
 
 }
 
+#connection{
+  font-size: 12px;
+    width: 100px;
+    height: 40px;
+    background-color: lightcoral;
+margin-bottom: 10px;
+}
+
 #reset:hover, #submit:hover, #load:hover, #stop:hover, #save:hover{
     border: 1.5px solid transparent;
     -moz-border-image: -moz-linear-gradient(left, #3acfd5 0%, #3a4ed5 100%);

--- a/exercises/follow_line/web-template/assets/ws_code.js
+++ b/exercises/follow_line/web-template/assets/ws_code.js
@@ -8,6 +8,51 @@ stop_button.disabled = true;
 stop_button.style.opacity = "0.4";
 stop_button.style.cursor = "not-allowed";
 
+var connected_code = false;
+var connected_gui = false;
+var setup_completed = false;
+
+var connection_button = document.getElementById("connection");
+connection_button.onmouseover = function(event){
+	if (connected_code && connected_gui){
+		connection_button.textContent = "Disconnect";
+		connection_button.style.backgroundColor = 'whitesmoke';
+	}
+	else{
+		connection_button.textContent = "Connect";
+		connection_button.style.backgroundColor = 'whitesmoke';
+	}
+}
+
+connection_button.onmouseout = function(event){
+	if (connected_code && connected_gui){
+		connection_button.textContent = "Connected";
+		connection_button.style.backgroundColor = 'lightgreen';
+	}
+	else{
+		connection_button.textContent = "Disconnected";
+		connection_button.style.backgroundColor = 'lightcoral';
+
+	}
+}
+
+//
+connection_button.onclick = function(event){
+	if (!setup_completed){
+		alert("Please wait for the socket to be connected!!");
+	}
+	else if(connected_code && connected_gui){
+
+		websocket_code.close(1000, "Disconnect button click");
+		websocket_gui.close(1000, "Disconnect button click");
+	}
+	else{
+		
+		declare_code(websocket_address);
+		declare_gui(websocket_address);			
+	}
+}
+
 // running variable for psuedo decoupling 
 // Play/Pause from Reset
 var frequency = "0",
@@ -16,10 +61,17 @@ var frequency = "0",
 //WebSocket for Code
 var websocket_code;
 function declare_code(websocket_address){
-	websocket_code = new WebSocket("ws://" + websocket_address + ":1905/");
+	
+	websocket_code = new WebSocket("ws://" + websocket_address + ":1905/");	
 
 	websocket_code.onopen = function(event){
 		alert("[open] Connection established!");
+		connected_code = true;
+		if (connected_code && connected_gui){
+			connection_button.textContent = "Disconnect";
+			connection_button.style.backgroundColor = 'whitesmoke';
+		}
+
 	}
 	websocket_code.onclose = function(event){
 		if(event.wasClean){
@@ -27,6 +79,11 @@ function declare_code(websocket_address){
 		}
 		else{
 			alert("[close] Connection closed!");
+		}
+		connected_code = false;
+		if (!connected_code && !connected_gui){
+			connection_button.textContent = "Connect";
+			connection_button.style.backgroundColor = 'whitesmoke';	
 		}
 	}
 

--- a/exercises/follow_line/web-template/assets/ws_gui.js
+++ b/exercises/follow_line/web-template/assets/ws_gui.js
@@ -15,6 +15,11 @@ function declare_gui(websocket_address){
 
 	websocket_gui.onopen = function(event){
 		alert("[open] Connection established!");
+		connected_gui = true;
+		if (connected_code && connected_gui){
+			connection_button.textContent = "Disconnect";
+			connection_button.style.backgroundColor = 'whitesmoke';
+		}
 	}
 	
 	websocket_gui.onclose = function(event){
@@ -23,6 +28,11 @@ function declare_gui(websocket_address){
 		}
 		else{
 			alert("[close] Connection closed!");
+		}
+		connected_gui = false;
+		if (!connected_code && !connected_gui){
+			connection_button.textContent = "Connect";
+			connection_button.style.backgroundColor = 'whitesmoke';	
 		}
 	}
 

--- a/exercises/follow_line/web-template/exercise.html
+++ b/exercises/follow_line/web-template/exercise.html
@@ -20,6 +20,11 @@
         <div class="content">
 
             <div class="split a">
+              
+              <div class="connection">
+                <button id="connection" type="button">Disconnected</button>
+              </div>
+
               <div id="Control" class="container" >
                 <button  id="submit" type="button" onclick="submitCode()"><img src="./assets/img/submit.png"> Play </button>
                 <button  id="stop" type="button" onclick="stopCode()"><img src="./assets/img/pause.png"> Stop</button>


### PR DESCRIPTION
This is PR fixes #766.
I have added a connect button only for the follow line exercise, to get some feedback before adding the button to the other web template exercises as well.

The button text describes the current status of the connection (Connected/Disconnected). Once you move the cursor over the button, the text describes what will happen if you click the button (Disconnect/Connect). 

When the button was clicked immediately after the page was loaded and before ws_manager had received 2 "Done" messages, I was getting an error ERR_SOCKET_NOT_CONNECTED when trying to create a new websocket (in the declare_code and declare_gui function calls). To solve this problem, if the ws_manager hasn't received the "Done" messages and the button is pressed, an alert message is shown and the user will have to press again the button in order to connect.

I did not place the connection button with the other buttons (Start, Stop, Save, Load, Reset), as I think that their functionality is different and this should be depicted in the UI.

Any feedback will be much appreciated.