### PR TITLE
Removed saveCode() and loadCode() functions for exercises running via the web template

### DIFF
--- a/exercises/color_filter/web-template/assets/ws_code.js
+++ b/exercises/color_filter/web-template/assets/ws_code.js
@@ -81,24 +81,6 @@ function stopCode(){
 	running = false;
 }
 
-// Function to save the code
-function saveCode(){
-	// Get the code from editor and add header
-
-	var python_code = editor.getValue();
-	python_code = "#save" + python_code;
-	console.log("Code Sent! Check terminal for more information!");
-	websocket_code.send(python_code)
-}
-
-// Function to load the code
-function loadCode(){
-	// Send message to initiate load message
-	var message = "#load";
-	websocket_code.send(message);
-
-}
-
 // Function for range slider
 function codefrequencyUpdate(vol) {
 	document.querySelector('#code_frequency').value = vol;

--- a/exercises/follow_line/web-template/assets/ws_code.js
+++ b/exercises/follow_line/web-template/assets/ws_code.js
@@ -81,24 +81,6 @@ function stopCode(){
 	running = false;
 }
 
-// Function to save the code
-function saveCode(){
-	// Get the code from editor and add header
-	
-	var python_code = editor.getValue();
-	python_code = "#save" + python_code;
-	console.log("Code Sent! Check terminal for more information!");
-	websocket_code.send(python_code)
-}
-
-// Function to load the code
-function loadCode(){
-	// Send message to initiate load message
-	var message = "#load";
-	websocket_code.send(message);
-	
-}
-
 // Function to command the simulation to reset
 function resetSim(){
 	// Send message to initiate reset


### PR DESCRIPTION
This pull request is in reference to #876 

Removed `saveCode()` and `loadCode()` functions as they are no longer needed for execution from web template. This is because these functions hand over the save/load procedure to `exercise.py`, which is running on the docker container. Saving and loading from the Docker Image wouldn't make sense as those files would be deleted when a running container is removed.
The `local_functions.js` file is instead used now to save/load code to/from the web template.


