### PR TITLE
Reshape 1 channel images to 3 channel when sent to GUI

### DIFF
--- a/exercises/static/exercises/follow_line/web-template/user_functions.py
+++ b/exercises/static/exercises/follow_line/web-template/user_functions.py
@@ -1,5 +1,7 @@
 from shared.image import SharedImage
 from shared.value import SharedValue
+import numpy as np
+import cv2
 
 # Define HAL functions
 class HALFunctions:
@@ -30,4 +32,7 @@ class GUIFunctions:
 
     # Show image function
     def showImage(self, image):
+        # Reshape to 3 channel if it has only 1 in order to display it
+        if (len(image.shape) < 3):
+            image = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
         self.shared_image.add(image)


### PR DESCRIPTION
Images sent to display are reshaped if the are only 1 channel in order to avoid errors.