### PR TITLE
Update README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,8 +25,8 @@ First you need to build the image. Then, you need to run a container.
 ```
 git clone https://github.com/JdeRobot/RoboticsAcademy.git -b noetic
 cd scripts
-docker build -t image-name .
-docker run -it --name=container_name -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy ./start.sh
+./build.sh <tag>
+docker run -it --name=container_name -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy:<tag> ./start.sh
 ```
 
 ## Manager Script


### PR DESCRIPTION
There's no deafult `Dockerfile` in the scripts folder. To reflect to `Dockerfile-noetic-3.1` we need to run `build.sh`, otherwise it shows an error.

![Screenshot from 2021-07-01 11-03-27](https://user-images.githubusercontent.com/42846105/124070999-5a31ed80-da5c-11eb-94b7-debc899ea814.png)
