### PR TITLE
Stop and resume functions controlled by manager

### DIFF
--- a/exercises/static/exercises/follow_line/web-template/assets/controller.js
+++ b/exercises/static/exercises/follow_line/web-template/assets/controller.js
@@ -17,6 +17,9 @@ function start(){
 
 // Function to stop the student solution
 function stop(){
+    // Code Websocket
+    stopCode();
+    
     // Manager Websocket
     if (running == true) {
         stopSimulation();
@@ -28,6 +31,9 @@ function stop(){
 
 // Function to reset the simulation
 function reset(){
+    // Code Websocket
+    stopCode();
+
     // Manager Websocket
     resetSimulation();
 

--- a/exercises/static/exercises/follow_line/web-template/assets/controller.js
+++ b/exercises/static/exercises/follow_line/web-template/assets/controller.js
@@ -1,35 +1,33 @@
 // Main message controller for websockets
-var running = true;
+var running = false;
 
 // Function to execute the student solution
 function start(){
+    // Manager Websocket
+    if (running == false) {
+        resumeSimulation();
+    }
+
     // Code Websocket
     submitCode();
 
     // GUI Websocket
     unpause_lap();
-
-    // Mark the variables
-    running = true;
 }
 
 // Function to stop the student solution
 function stop(){
-    // Code Websocket
-    stopCode();
+    // Manager Websocket
+    if (running == true) {
+        stopSimulation();
+    }
 
     // GUI Websocket
     pause_lap();
-
-    // Mark the variables
-    running = false;
 }
 
 // Function to reset the simulation
 function reset(){
-    // Code websocket
-    stopCode();
-
     // Manager Websocket
     resetSimulation();
 

--- a/exercises/static/exercises/follow_line/web-template/assets/launcher.js
+++ b/exercises/static/exercises/follow_line/web-template/assets/launcher.js
@@ -1,6 +1,8 @@
 var ws_manager;
 var gazeboToggle = false, gazeboOn = false;
 var simReset = false;
+var simStop = false;
+var simResume = false;
 
 function startSim() {
     ws_manager = new WebSocket("ws://" + websocket_address + ":8765/");
@@ -46,7 +48,15 @@ function startSim() {
             } else if (simReset){
                 ws_manager.send(JSON.stringify({"command": "reset"}));
                 simReset = false;
-            } 
+            } else if (simStop){
+                ws_manager.send(JSON.stringify({"command": "stop"}));
+                simStop = false;
+                running = false;
+            } else if (simResume){
+                ws_manager.send(JSON.stringify({"command": "start"}));
+                simResume = false;
+                running = true;
+            }
             else {
                 setTimeout(function () {
                     ws_manager.send(JSON.stringify({"command" : "Pong"}));
@@ -68,4 +78,12 @@ function toggleGazebo() {
 
 function resetSimulation() {
     simReset = true;
+}
+
+function stopSimulation() {
+    simStop = true;
+}
+
+function resumeSimulation() {
+    simResume = true;
 }

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -269,8 +269,10 @@ class Manager:
                 self.resume_simulation()
             elif command == "stop":
                 self.stop_simulation()
+                await websocket.send("Ping{}".format(self.launch_level))
             elif command == "start":
                 self.start_simulation()
+                await websocket.send("Ping{}".format(self.launch_level))
             elif command == "reset":
                 self.reset_simulation()
                 await websocket.send("Ping{}".format(self.launch_level))


### PR DESCRIPTION
manager.py controlls stop and resume functions. I tried to use similar functions. I only changed `running` variable set from controller.js to launcher.js, as it could create an error (running variable set to false when running, or to true when stopped) if the buttons were clicked two times before the "Ping" message was sent.