### PR TITLE
centered an image in mobile view

### DIFF
--- a/_sass/minimal-mistakes/_base.scss
+++ b/_sass/minimal-mistakes/_base.scss
@@ -209,7 +209,7 @@ figure {
   display: -webkit-box;
   display: flex;
   -webkit-box-pack: justify;
-  justify-content: space-between;
+  justify-content: center;
   -webkit-box-align: start;
   align-items: flex-start;
   flex-wrap: wrap;


### PR DESCRIPTION
Google summer of code image was left aligned when viewing from a mobile device. I have centered it to look better.