### PR TITLE
Makefile fixed

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -50,7 +50,7 @@ RUN cp -r /opt/jderobot/CustomRobots/SelfDrivingModels /catkin_ws/src/SelfDrivin
 RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash; cd /catkin_ws; catkin build catvehicle'
 
 # RoboticsAcademy
-RUN git clone https://github.com/JdeRobot/RoboticsAcademy.git -b new-architecture
+RUN git clone https://github.com/JdeRobot/RoboticsAcademy.git -b master
 # RUN rsync -a --exclude 'ace-builds' /RoboticsAcademy/exercises/static/exercises/* /RoboticsAcademy/exercises
 
 # React

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -3,7 +3,7 @@ DOCKER_USERNAME ?= jderobot
 BASE_NAME ?= robotics-applications
 APP_NAME ?= robotics-academy
 BUILD_TAG ?= test
-# VERSION ?= 3.2.14
+
 
 all: help
 
@@ -14,18 +14,24 @@ help: ## Print help info
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ""
 
+
 # Docker building
 build:  ## Build RADI
-	@docker build --no-cache=true -t $(DOCKER_USERNAME)/$(APP_NAME):test .
+	@docker build --no-cache=true -t $(DOCKER_USERNAME)/$(APP_NAME):$(BUILD_TAG) .
 
 build-base:  ## Build RADI base
 	@docker build -f Dockerfile.base -t $(DOCKER_USERNAME)/$(BASE_NAME):base .
 
 build-all: build-base build  ## Build RADI and base
 
-# Docker run
-run:
-	@echo Not implemented
+
+# Docker run test image
+run-test:  ## Run last built RADI
+	@docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy:$(BUILD_TAG)
+
+run:  ## Run RADI
+	@echo See run instructions at https://jderobot.github.io/RoboticsAcademy/exercises/
+
 
 # Docker pull
 pull:  ## Pull latest RADI
@@ -38,36 +44,31 @@ clean:  ## Remove RADI image
 	@docker rmi -f $(DOCKER_USERNAME)/$(APP_NAME)
 
 
-ifeq ($(VERSION),)
-$(info VERSION not set! Run it again with VERSION="X.Y.Z")
-
-else
 # Docker release
-release: build publish  ## Make a release by building and publishing the `{version}` and `latest` tagged containers to dockerhub
+release: build publish  ## Build and publish the `{version}` and `latest` tagged containers to dockerhub
+
 
 # Docker publish
-publish: publish-latest publish-version  ## Publish the `{version}` and `latest` tagged containers to dockerhub
-
-publish-latest: tag-latest ## Publish the `latest` taged container to dockerhub
-	@echo 'publish latest to $(DOCKER_USERNAME)'
-	@docker push $(DOCKER_USERNAME)/$(APP_NAME):latest
+publish: publish-version publish-latest  ## Publish the `{version}` and `latest` tagged containers to dockerhub
 
 publish-version: tag-version ## Publish the `{version}` taged container to dockerhub
-	@echo 'publish $(VERSION) to $(DOCKER_REPO)'
 	@docker push $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
 
+publish-latest: tag-latest ## Publish the `latest` taged container to dockerhub
+	@docker push $(DOCKER_USERNAME)/$(APP_NAME):latest
+
+
 # Docker tagging
-tag: tag-latest tag-version ## Generate container tags for the `{version}` ans `latest` tags
+tag: tag-version tag-latest ## Generate container tags for the `{version}` ans `latest` tags
+
+tag-version: version ## Generate container `latest` tag
+	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
 
 tag-latest: ## Generate container `{version}` tag
-	@echo 'create tag latest'
-	@docker tag jderobot/robotics-academy:test $(DOCKER_USERNAME)/$(APP_NAME):latest
+	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):latest
 
-tag-version: ## Generate container `latest` tag
-	@echo 'create tag $(VERSION)'
-	@docker tag jderobot/robotics-academy:test $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
 
+# Version
 version: ## Output the current version
-	@echo $(VERSION)
-
-endif
+	@if [ -z "${VERSION}" ] ; then echo "VERSION must be set" ; false ; fi
+	@echo VERSION=$(VERSION)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -52,7 +52,7 @@ release: build publish  ## Build and publish the `{version}` and `latest` tagged
 publish: --publish-version --publish-latest  ## Publish the `{version}` and `latest` tagged containers to dockerhub
 
 --publish-version: tag-version
-	@docker push $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
+	@docker push $(DOCKER_USERNAME)/$(APP_NAME):$(RADI_TAG)
 
 --publish-latest: tag-latest
 	@docker push $(DOCKER_USERNAME)/$(APP_NAME):latest
@@ -62,13 +62,13 @@ publish: --publish-version --publish-latest  ## Publish the `{version}` and `lat
 tag: --tag-version --tag-latest  ## Generate container tags for the `{version}` ans `latest` tags
 
 --tag-version: version
-	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
+	@docker tag $(DOCKER_USERNAME)/$(APP_NAME):$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):$(RADI_TAG)
 
 --tag-latest:
-	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):latest
+	@docker tag $(DOCKER_USERNAME)/$(APP_NAME):$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):latest
 
 
 # Version
 version:  ## Output the current version
-	@if [ -z "${VERSION}" ] ; then echo "VERSION must be set, try 'make version VERSION=tag'" ; false ; fi
-	@echo Using VERSION=$(VERSION)
+	@if [ -z "${RADI_TAG}" ] ; then echo "RADI_TAG must be set, try 'make version RADI_TAG=version'" ; false ; fi
+	@echo Using RADI_TAG=$(RADI_TAG)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -7,7 +7,7 @@ BUILD_TAG ?= test
 
 all: help
 
-help: ## Print help info
+help:  ## Print help info
 	@echo ""
 	@echo "-- Help Menu"
 	@echo ""
@@ -26,8 +26,8 @@ build-all: build-base build  ## Build RADI and base
 
 
 # Docker run test image
-run-test:  ## Run last built RADI
-	@docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy:$(BUILD_TAG)
+test:  ## Run last built RADI
+	@docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 -p 7163:7163 $(DOCKER_USERNAME)/$(APP_NAME):$(BUILD_TAG)
 
 run:  ## Run RADI
 	@echo See run instructions at https://jderobot.github.io/RoboticsAcademy/exercises/
@@ -49,26 +49,26 @@ release: build publish  ## Build and publish the `{version}` and `latest` tagged
 
 
 # Docker publish
-publish: publish-version publish-latest  ## Publish the `{version}` and `latest` tagged containers to dockerhub
+publish: --publish-version --publish-latest  ## Publish the `{version}` and `latest` tagged containers to dockerhub
 
-publish-version: tag-version ## Publish the `{version}` taged container to dockerhub
+--publish-version: tag-version
 	@docker push $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
 
-publish-latest: tag-latest ## Publish the `latest` taged container to dockerhub
+--publish-latest: tag-latest
 	@docker push $(DOCKER_USERNAME)/$(APP_NAME):latest
 
 
 # Docker tagging
-tag: tag-version tag-latest ## Generate container tags for the `{version}` ans `latest` tags
+tag: --tag-version --tag-latest  ## Generate container tags for the `{version}` ans `latest` tags
 
-tag-version: version ## Generate container `latest` tag
+--tag-version: version
 	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):$(VERSION)
 
-tag-latest: ## Generate container `{version}` tag
+--tag-latest:
 	@docker tag jderobot/robotics-academy:$(BUILD_TAG) $(DOCKER_USERNAME)/$(APP_NAME):latest
 
 
 # Version
-version: ## Output the current version
-	@if [ -z "${VERSION}" ] ; then echo "VERSION must be set" ; false ; fi
-	@echo VERSION=$(VERSION)
+version:  ## Output the current version
+	@if [ -z "${VERSION}" ] ; then echo "VERSION must be set, try 'make version VERSION=tag'" ; false ; fi
+	@echo Using VERSION=$(VERSION)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,10 +47,8 @@ if $force_build || [[ "$(docker images -q jderobot/robotics-applications:base 2>
   echo "BUILDING Jderobot BASE IMAGE ====================="
   echo
   docker build -f Dockerfile.base -t jderobot/robotics-applications:base .
-  # make build-base
 fi
 
 echo "BUILDING RoboticsAcademy RADI IMAGE ====================="
 echo
 docker build --no-cache=true -t jderobot/robotics-academy:$image_tag .
-# make build VERSION=$image_tag


### PR DESCRIPTION
This recipe may easy the docker usage for newcomers. Help message is self-explained:
```bash
$ make help

-- Help Menu

help                           Print help info
build                          Build RADI
build-base                     Build RADI base
build-all                      Build RADI and base
test                           Run last built RADI
run                            Run RADI
pull                           Pull latest RADI
prune                          Prune all images
clean                          Remove RADI image
release                        Build and publish the `{version}` and `latest` tagged containers to dockerhub
publish                        Publish the `{version}` and `latest` tagged containers to dockerhub
tag                            Generate container tags for the `{version}` ans `latest` tags
version                        Output the current version
```

Anyway, some easy examples (go to makefile containing folder to run them):
- How to build RADI: `make build`
- How to build RADi and base: `make build-all`
- How to run the last built RADI: `make test`
- How to push RADi to dockerhub: `make release RADI_TAG=<version>`

## Some implementation details
- Build tag is `test` by default
- `release` rule only builds RADI, not base
- `release`, `publish`, `tag` and `version` need RADI_TAG argument
- `clean` only removes RADI images, including latest but not the base
- Releasing or publishing need dockerhub authentication

@ango1994 could you please test it while releasing RADI v3.3.0?