### PR TITLE
Make DRI device configurable to enable GPU acceleration 

### DIFF
--- a/docs/gpu_acceleration.md
+++ b/docs/gpu_acceleration.md
@@ -1,0 +1,41 @@
+### [Back to main README.][]
+
+[Back to main README.]: ../README.md
+
+# GPU Acceleration
+ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+
+## Linux
+
+### Intel
+For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
+```
+docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+
+### NVIDIA
+For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
+```
+docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+
+### Dual
+If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```).
+```
+docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+
+You can check the names associated with your graphic cards by running:
+```
+ drm-info -j | jq 'with_entries(.value |= .driver.desc)'
+```
+You should get something like:
+```
+{
+  "/dev/dri/card1": "NVIDIA DRM driver",
+  "/dev/dri/card0": "Intel Graphics"
+}
+```
+
+## Windows
+Pending validation.

--- a/exercises/static/exercises/drone_cat_mouse/web-template/launch/launch.py
+++ b/exercises/static/exercises/drone_cat_mouse/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "drone_cat_mouse"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/drone_gymkhana/web-template/launch/launch.py
+++ b/exercises/static/exercises/drone_gymkhana/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "drone_gymkhana"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/drone_hangar/web-template/launch/launch.py
+++ b/exercises/static/exercises/drone_hangar/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "drone_hangar"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/follow_road/web-template/launch/launch.py
+++ b/exercises/static/exercises/follow_road/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "follow_road"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/follow_turtlebot/web-template/launch/launch.py
+++ b/exercises/static/exercises/follow_turtlebot/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "follow_turtlebot"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -14,7 +15,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/labyrinth_escape/web-template/launch/launch.py
+++ b/exercises/static/exercises/labyrinth_escape/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "labyrinth_escape"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/package_delivery/web-template/launch/launch.py
+++ b/exercises/static/exercises/package_delivery/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "package_delivery"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/position_control/web-template/launch/launch.py
+++ b/exercises/static/exercises/position_control/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "position_control"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/power_tower_inspection/web-template/launch/launch.py
+++ b/exercises/static/exercises/power_tower_inspection/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "power_tower_inspection"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Function to check if a device exists
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/power_tower_inspection_react/web-template/launch/launch.py
+++ b/exercises/static/exercises/power_tower_inspection_react/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "power_tower_inspection"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Function to check if a device exists
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/rescue_people/web-template/launch/launch.py
+++ b/exercises/static/exercises/rescue_people/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "rescue_people"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/rescue_people_react/web-template/launch/launch.py
+++ b/exercises/static/exercises/rescue_people_react/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "rescue_people"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/exercises/static/exercises/visual_lander/web-template/launch/launch.py
+++ b/exercises/static/exercises/visual_lander/web-template/launch/launch.py
@@ -2,11 +2,12 @@
 
 import stat
 import rospy
-from os import lstat
+import os
 from subprocess import Popen, PIPE
 
 
-DRI_PATH = "/dev/dri/card0"
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 EXERCISE = "visual_lander"
 TIMEOUT = 30
 MAX_ATTEMPT = 2
@@ -15,7 +16,7 @@ MAX_ATTEMPT = 2
 # Check if acceleration can be enabled
 def check_device(device_path):
     try:
-        return stat.S_ISCHR(lstat(device_path)[stat.ST_MODE])
+        return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
     except:
         return False
 

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -22,8 +22,11 @@ def check_device(device_path):
         return False
 
 RADI_VERSION = "3.2.9"
-DRI_PATH = "/dev/dri/card0"
+
+# If DRI_NAME is not set by user, use card0
+DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
 ACCELERATION_ENABLED = check_device(DRI_PATH)
+
 DRONE_EX = ["drone_cat_mouse", "follow_road", "follow_turtlebot", "labyrinth_escape", "position_control",
             "rescue_people", "drone_hangar", "drone_gymkhana", "visual_lander", "drone_cat_mouse_game",
             "package_delivery", "power_tower_inspection"]


### PR DESCRIPTION
As of now, DRI device address is hardcoded (`/dev/dri/card0`), and so users can't choose which GPU to use for acceleration.

In this PR, we include changes to allow users to set the environment variable `DRI_NAME` when running the Docker container. If a user has an integrated Intel GPU and a dedicated NVIDIA one, the user can set this new env variable accordingly and choose which GPU to use. Further instructions are provided in [gpu_acceleration.md](https://github.com/JdeRobot/RoboticsAcademy/blob/b24f67208427f05787c5db3dc7f6ee257e3b25f1/docs/gpu_acceleration.md).

Solves issue #1948 