### PR TITLE
Restructured install and launch docs

### DIFF
--- a/_pages/exercises/AutonomousCars/autoparking.md
+++ b/_pages/exercises/AutonomousCars/autoparking.md
@@ -46,62 +46,21 @@ The objective of this practice is to implement the logic of a navigation algorit
 
 ## Instructions
 
-### Installation
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Clone the Robotics Academy repository on your local machine
-
-	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -112,6 +71,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/AutonomousCars/car-junction.md
+++ b/_pages/exercises/AutonomousCars/car-junction.md
@@ -69,60 +69,21 @@ The goal of this practice is to implement the logic of a navigation algorithm fo
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -133,6 +94,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/AutonomousCars/follow_line.md
+++ b/_pages/exercises/AutonomousCars/follow_line.md
@@ -69,11 +69,10 @@ The students will program a Formula1 car in a race circuit to follow the red lin
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -81,43 +80,10 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -128,6 +94,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/AutonomousCars/global_navigation.md
+++ b/_pages/exercises/AutonomousCars/global_navigation.md
@@ -127,70 +127,34 @@ The solution can integrate one or more of the following levels of difficulty, as
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-```
+2. Pull the current distribution of Robotics Academy Docker Image:
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-```bash
-docker pull jderobot/robotics-academy:latest
-```
+	```bash
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background
-
-```bash
-docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
 
 - On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
 
-- Click the connect button and wait for some time until an alert appears with the message `Connection Established` and button displays connected. 
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/AutonomousCars/obstacle_avoidance.md
+++ b/_pages/exercises/AutonomousCars/obstacle_avoidance.md
@@ -71,61 +71,21 @@ The solution can integrate one or more of the following levels of difficulty, as
 ## Instructions
 This is the preferred way to run the exercise.
 
-### Installation
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Clone the Robotics Academy repository on your local machine
-
-	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -136,6 +96,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/ComputerVision/3d_reconstruction.md
+++ b/_pages/exercises/ComputerVision/3d_reconstruction.md
@@ -64,60 +64,21 @@ In this practice, the intention is to program the necessary logic to allow kobuk
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -128,6 +89,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/ComputerVision/montecarlo_visual_loc.md
+++ b/_pages/exercises/ComputerVision/montecarlo_visual_loc.md
@@ -51,28 +51,25 @@ The aim of this practice is to develop a visual localisation algorithm based on 
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-```
+2. Pull the current distribution of Robotics Academy Docker Image:
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+	```bash
+  docker pull jderobot/robotics-academy:latest
+  ```
 
-- Pull the current distribution of Robotics Academy Docker Image
+- In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-```bash
-docker pull jderobot/robotics-academy:latest
-```
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background. It is necessary to map the port where the camera is located to the docker container.  
-- For ubuntu: The port to map will be in /dev/videoX , you should check the number where your camera is connected. For exaple /dev/video0
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
-```bash
-docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```   
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
 
 - On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
 
@@ -80,6 +77,8 @@ docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:
 
 - The exercise can be used after the alert.
 
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/Drones/drone_cat_mouse.md
+++ b/_pages/exercises/Drones/drone_cat_mouse.md
@@ -30,11 +30,10 @@ In this exercise, the cat quadrotor has to be programmed by the student to follo
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -42,40 +41,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -87,19 +69,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 -p 2304:2304 -p 1904:1904 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/drone_gymkhana.md
+++ b/_pages/exercises/Drones/drone_gymkhana.md
@@ -39,11 +39,10 @@ You will have contact with the drone infrastructure in our Robotics Academy for 
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -51,39 +50,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -95,19 +78,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/drone_hangar.md
+++ b/_pages/exercises/Drones/drone_hangar.md
@@ -27,14 +27,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to e
 
 {% include gallery caption="Gallery." %}
 
-## Instructions
-This is the preferred way for running the exercise.
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-### Installation 
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -42,40 +38,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -87,19 +66,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/follow_road.md
+++ b/_pages/exercises/Drones/follow_road.md
@@ -46,11 +46,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to f
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -58,40 +57,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -103,19 +85,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/follow_turtlebot.md
+++ b/_pages/exercises/Drones/follow_turtlebot.md
@@ -27,11 +27,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to f
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -39,40 +38,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -84,19 +66,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/labyrinth_escape.md
+++ b/_pages/exercises/Drones/labyrinth_escape.md
@@ -25,53 +25,34 @@ The goal of this exercise is to implement the logic that allows a quadrotor to e
 
 ## Instructions
 
-### Installation
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-First, pull the last version of our [docker image](https://hub.docker.com/r/jderobot/robotics-academy):
-```bash
-docker pull jderobot/robotics-academy:latest
-```
+2. Pull the current distribution of Robotics Academy Docker Image:
 
-Notice that you have to have installed [Docker](https://docs.docker.com/get-docker/) to complete the previous step.
+	```bash
+  docker pull jderobot/robotics-academy:latest
+  ```
 
-Secondly, clone the Robotics Academy repository on your local machine:
-```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-```
+- In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
+
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -83,17 +64,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 ### How should I solve the exercise?
 The launched webpage contains several widgets that will help you to solve the exercise.

--- a/_pages/exercises/Drones/package_delivery.md
+++ b/_pages/exercises/Drones/package_delivery.md
@@ -30,11 +30,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to d
 
 ## Instructions
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -42,40 +41,23 @@ The goal of this exercise is to implement the logic that allows a quadrotor to d
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -87,19 +69,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/position_control.md
+++ b/_pages/exercises/Drones/position_control.md
@@ -46,11 +46,10 @@ For this exercise, a world has been designed in gazebo that contains the Iris qu
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -58,40 +57,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -103,19 +85,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/power_tower_inspection.md
+++ b/_pages/exercises/Drones/power_tower_inspection.md
@@ -29,11 +29,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to p
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -41,40 +40,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -86,19 +68,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/rescue_people.md
+++ b/_pages/exercises/Drones/rescue_people.md
@@ -37,11 +37,10 @@ While survivors are known to be close to **40º16'47.23" N**, **3º49'01.78" W**
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -49,40 +48,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -94,19 +76,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/Drones/visual_lander.md
+++ b/_pages/exercises/Drones/visual_lander.md
@@ -27,11 +27,10 @@ The goal of this exercise is to implement the logic that allows a quadrotor to v
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
   docker pull jderobot/robotics-academy:latest
@@ -39,40 +38,23 @@ This is the preferred way for running the exercise.
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
 ### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
-
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 ### Optional: Store terminal output
 - To store the terminal output of manager.py and launch.py to a file execute the following docker run command and keep it running in the background:
@@ -84,19 +66,6 @@ docker run -it --rm -v $HOME/.roboticsacademy/log/:/root/.roboticsacademy/log/ -
 ```bash
 more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 ```
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration)/[store terminal output](#optional-store-terminal-output))
-
-	```bash
-  docker run -it --rm -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-  ```
-
-- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
-
-- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
-
-- The exercise can be used after the alert.
 
 ### Where to insert the code?
 

--- a/_pages/exercises/MobileRobots/laser_mapping.md
+++ b/_pages/exercises/MobileRobots/laser_mapping.md
@@ -33,25 +33,21 @@ The objective of this practice is to implement the logic of a navigation algorit
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -59,9 +55,12 @@ docker pull jderobot/robotics-academy:latest
 
 - On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
 
-- Click the connect button and wait for some time until an alert appears with the message `Connection Established` and button displays connected.
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/MobileRobots/vacuum_cleaner.md
+++ b/_pages/exercises/MobileRobots/vacuum_cleaner.md
@@ -28,60 +28,21 @@ The objective of this practice is to implement the logic of a navigation algorit
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -92,6 +53,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/exercises/MobileRobots/vacuum_cleaner_loc.md
+++ b/_pages/exercises/MobileRobots/vacuum_cleaner_loc.md
@@ -31,60 +31,21 @@ The objective of this practice is to implement the logic of a navigation algorit
 ## Instructions
 This is the preferred way for running the exercise.
 
-### Installation 
-- Clone the Robotics Academy repository on your local machine
+### Installing and Launching
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
+
+2. Pull the current distribution of Robotics Academy Docker Image:
 
 	```bash
-git clone https://github.com/JdeRobot/RoboticsAcademy
-	```
-
-- Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
-
-- Pull the current distribution of Robotics Academy Docker Image
-
-	```bash
-docker pull jderobot/robotics-academy:latest
-	```
+  docker pull jderobot/robotics-academy:latest
+  ```
 
 - In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
 
-### Enable GPU Acceleration
-ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
 
-### Linux
-
-
-- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
-```bash
-docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
-```bash
-docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-
-- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
-```bash
-docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
-```
-You can check the names associated with your graphic cards by running:
-```bash
- drm-info -j | jq 'with_entries(.value |= .driver.desc)'
-```
-You should get something like:
-```bash
-{
-  "/dev/dri/card1": "NVIDIA DRM driver",
-  "/dev/dri/card0": "Intel Graphics"
-}
-```
-
-### Windows
-For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/)
-
-### How to perform the exercise?
-- Start a new docker container of the image and keep it running in the background ([hardware accelerated version](#enable-gpu-acceleration))
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
 
 	```bash
   docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
@@ -95,6 +56,9 @@ For Windows machines, GPU acceleration to Docker is an experimental approach and
 - Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
 
 - The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
 
 **Where to insert the code?**
 

--- a/_pages/gpu_acceleration.md
+++ b/_pages/gpu_acceleration.md
@@ -1,0 +1,44 @@
+---
+permalink: /gpu_acceleration/
+title: "GPU Acceleration Instructions"
+
+sidebar:
+  nav: "docs"
+
+toc: true
+toc_label: "TOC GPU Acceleration"
+toc_icon: "cog"
+---
+ROS and Gazebo can be accelerated within RoboticsAcademy thanks to VirtualGL if a GPU is available.
+
+### Linux
+
+
+- **Intel:** For Linux machines and Intel GPUs, acceleration can be achieved by simply setting the ```--device``` argument when running the Docker container:
+```bash
+docker run --rm -it --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+
+- **NVIDIA:** For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-container-runtime package](https://docs.docker.com/config/containers/resource_constraints/#gpu), and then running the command above, but adding the ```--gpus all``` flag:
+```bash
+docker run --rm -it --gpus all --device /dev/dri -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+
+- **MULTIPLE GPUs:** If the PC has several GPUs, we can choose which one will be used by setting the ```DRI_NAME``` environment variable (e.g. ```card0``` or ```card1```)
+```bash
+docker run --rm -it --gpus all --device /dev/dri -e DRI_NAME=card1 -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+```
+You can check the names associated with your graphic cards by running:
+```bash
+ drm-info -j | jq 'with_entries(.value |= .driver.desc)'
+```
+You should get something like:
+```bash
+{
+  "/dev/dri/card1": "NVIDIA DRM driver",
+  "/dev/dri/card0": "Intel Graphics"
+}
+```
+
+### Windows
+For Windows machines, GPU acceleration to Docker is an experimental approach and can be implemented as per instructions given [here](https://www.docker.com/blog/wsl-2-gpu-support-is-here/).

--- a/_pages/installation.md
+++ b/_pages/installation.md
@@ -1,6 +1,6 @@
 ---
 permalink: /installation/
-title: "INSTALLATION INSTRUCTIONS"
+title: "Installation Instructions"
 
 sidebar:
   nav: "docs"
@@ -12,7 +12,31 @@ toc_icon: "cog"
 
 **Robotics-Academy** supports Linux (Ubuntu 18.04, 20.04 and other distributions), MacOS and Windows. The installation has been greatly simplified, as all the required dependencies are already pre-installed in the Robotics-Academy Docker Image. The users of this release should:
 
-1. Install [Docker](https://www.docker.com/) on their machines
-2. Run the [RADI (Robotics-Academy Docker Image)](https://hub.docker.com/r/jderobot/robotics-academy/tags) using the exercise specific launch instructions
+1. Download [Docker](https://docs.docker.com/get-docker/). Windows users should choose WSL 2 backend Docker installation if possible, as it has better performance than Hyper-V.
 
-Enjoy :-)
+2. Pull the current distribution of Robotics Academy Docker Image:
+
+	```bash
+  docker pull jderobot/robotics-academy:latest
+  ```
+
+- In order to obtain optimal performance, Docker should be using multiple CPU cores. In case of Docker for Mac or Docker for Windows, the VM should be assigned a greater number of cores.
+
+- It is recommended to use the latest image. However, older distributions of RADI (Robotics-Academy Docker Image) can be found [here](https://hub.docker.com/r/jderobot/robotics-academy/tags).
+
+### How to perform the exercises?
+- Start a new docker container of the image and keep it running in the background:
+
+	```bash
+  docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy
+  ```
+
+- On the local machine navigate to 127.0.0.1:8000/ in the browser and choose the desired exercise.
+
+- Wait for the Connect button to turn green and display "Connected". Click on the "Launch" button and wait for some time until an alert appears with the message `Connection Established` and button displays "Ready". 
+
+- The exercise can be used after the alert.
+
+### Enable GPU Acceleration
+- Follow the advanced launching instructions from [here](/gpu_acceleration).
+


### PR DESCRIPTION
#1963 Unified RADI install and launching instructions for all exercises except the ones that require a camera parameter to launch.
[Color Filter](https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/color_filter),
[Human Detection](https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/human_detection)
[Digit Classifier](https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/dl_digit_classifier)
[Optical Flow Teleop](https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/opticalflow_teleop)

I am unable to launch these exercises correctly #1973 . Hence refrained from updating their docs yet.

A few exercises like [vacuum cleaner](https://jderobot.github.io/RoboticsAcademy/exercises/MobileRobots/vacuum_cleaner) required cloning the git repository. Is that still required? @jmplaza @pariaspe 