### PR TITLE
updated docker ports

### DIFF
--- a/docs/InstructionsForDevelopers.md
+++ b/docs/InstructionsForDevelopers.md
@@ -47,7 +47,7 @@ The webserver is not connected with the RADI.
 
 6) To connect the webserver with RADI, Run:
 ```
-docker run --rm -it -p 8000:8000 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 jderobot/robotics-academy --no-server
+docker run --rm -it -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:6080 -p 1108:1108 -p 7163:7163 jderobot/robotics-academy --no-server
 ```
 
 <a name="How-to-add-a-new-exercise"></a>


### PR DESCRIPTION
- Removed 8080 here because point 5) runs django webserver which already opens 8080, trying to open it again in docker would cause this error :
![image](https://user-images.githubusercontent.com/40732709/227076207-7a7b0f2a-e9ea-431b-ad75-3e2937d5e62e.png)

- Added port 7163 for new RAM

@jmplaza @pariaspe 