### PR TITLE
#2027 fixed.

### DIFF
--- a/exercises/templates/exercises/RoboticsAcademy.html
+++ b/exercises/templates/exercises/RoboticsAcademy.html
@@ -27,7 +27,7 @@
     <div class="header">
       <p style="text-align:left;">
         Robotics Academy by JdeRobot
-        <a href="https://forum.jderobot.org/c/english/roboticsacademy/12"><span style="float:right;"><img src="{% static 'exercises/assets/img/forum.png' %}">  </img>Forum</span></a>
+        <a href="https://forum.unibotics.org/"><span style="float:right;"><img src="{% static 'exercises/assets/img/forum.png' %}">  </img>Forum</span></a>
         </p>
     </div>
 </nav>


### PR DESCRIPTION
This issue was leading to broken forum link as mentioned in #2027.

**Solution**
The solution was quite simple located the old href="https://forum.jderobot.org/c/english/roboticsacademy/12" and replaced it with new href="https://forum.unibotics.org/" which should fix it.

Let me know if you have any reviews or changes.