### PR TITLE
#2025 fixed.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Be sure to explain in details the context and the outcome that you are lookign f
 
 ## How to contribute in exercises documentation?
 
-Take a look at our [documentation guide lines](https://jderobot.github.io/RoboticsAcademy/contribute/) to contribute in github pages related issues.
+Take a look at our [documentation guide lines](https://jderobot.github.io/RoboticsAcademy/developer_guide) to contribute in github pages related issues.
 
 Thanks! :heart: :heart:
 RoboticsAcademy Team


### PR DESCRIPTION
Some links were redirecting to a 404 page which could be confusing for a new user as mentioned in #2025 .

Easy fix was to change some links in contributing.md so that they land on a page and don't show 404 error.