### PR TITLE
Humble base RADI refactoring 

### DIFF
--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -18,7 +18,7 @@ RUN apt-get clean && \
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-  
+
 ENV ROS_DISTRO=humble
 ENV AMENT_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
 ENV COLCON_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
@@ -31,7 +31,7 @@ ENV ROS_VERSION=2
 # Install common tools
 RUN apt-get update && apt-get install -y \
   software-properties-common \
-  bash-completion \    
+  bash-completion \
   apt-utils \
   build-essential \
   git curl wget cmake \
@@ -74,7 +74,7 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
     ros-${ROS_DISTRO}-gazebo* \
     ros-${ROS_DISTRO}-ros-gz* \
   && apt-get -y autoremove \
-	&& apt-get clean autoclean \
+  && apt-get clean autoclean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN mkdir ~/.gazebo && touch ~/.gazebo/gui.ini
 
@@ -90,31 +90,31 @@ RUN python3.10 -m pip install --upgrade pip wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN python3.10 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-		matplotlib==3.0.* numpy nunavut==1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
+    matplotlib==3.0.* numpy nunavut==1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+    pyyaml requests serial six toml psutil pyulog wheel onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
 
 # Install VNC
 # Xorg segfault error mitigation
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        dbus-x11 \
-        libdbus-c++-1-0v5 && \
-    rm -rf /var/lib/apt/lists/*
+    dbus-x11 \
+    libdbus-c++-1-0v5 \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y \
-  xvfb xauth xfonts-base xkb-data x11-xkb-utils \
+    xvfb xauth xfonts-base xkb-data x11-xkb-utils \
   && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
-		x11vnc \
-		xterm \
-		xserver-xorg-video-dummy \
-		x11-apps \
-	&& apt-get -y autoremove \
-	&& apt-get clean autoclean \
-	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+    x11vnc \
+    xterm \
+    xserver-xorg-video-dummy \
+    x11-apps \
+  && apt-get -y autoremove \
+  && apt-get clean autoclean \
+  && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN wget https://xpra.org/xorg.conf \
-    && rm -rf /tmp/*
+  && rm -rf /tmp/*
 
 # Install noVNC and websockify
 RUN git clone https://github.com/novnc/noVNC.git
@@ -124,8 +124,8 @@ RUN cd /noVNC/utils && git clone https://github.com/novnc/websockify.git
 COPY ./gpu/virtualgl_${VISRTUALGL_VERSION}_amd64.deb /
 RUN apt-get update && apt-get install -y \
     libegl1-mesa:amd64
-RUN apt-get update && dpkg -i /virtualgl_${VISRTUALGL_VERSION}_amd64.deb && \
-    rm /virtualgl_${VISRTUALGL_VERSION}_amd64.deb
+RUN apt-get update && dpkg -i /virtualgl_${VISRTUALGL_VERSION}_amd64.deb \
+  && rm /virtualgl_${VISRTUALGL_VERSION}_amd64.deb
 
 COPY ./gpu/virtualgl32_${VISRTUALGL_VERSION}_amd64.deb /
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
@@ -133,14 +133,14 @@ RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
     libxv1:i386 \
     libglu1-mesa:i386 \
     libegl1-mesa:i386
-RUN apt-get update && dpkg -i /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb && \
-    rm /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb && \
-    chmod u+s /usr/lib/libvglfaker.so && \
-    chmod u+s /usr/lib/libdlfaker.so && \
-    chmod u+s /usr/lib32/libvglfaker.so && \
-    chmod u+s /usr/lib32/libdlfaker.so  &&\
-    chmod u+s /usr/lib/i386-linux-gnu/libvglfaker.so && \
-    chmod u+s /usr/lib/i386-linux-gnu/libdlfaker.so 
+RUN apt-get update && dpkg -i /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb \
+  && rm /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb \
+  && chmod u+s /usr/lib/libvglfaker.so \
+  && chmod u+s /usr/lib/libdlfaker.so \
+  && chmod u+s /usr/lib32/libvglfaker.so \
+  && chmod u+s /usr/lib32/libdlfaker.so \
+  && chmod u+s /usr/lib/i386-linux-gnu/libvglfaker.so \
+  && chmod u+s /usr/lib/i386-linux-gnu/libdlfaker.so 
 
 # TurboVNC
 COPY ./gpu/turbovnc_${TURBOVNC_VERSION}_amd64.deb /
@@ -149,13 +149,13 @@ COPY ./gpu/turbovnc_${TURBOVNC_VERSION}_amd64.deb /
 #    rm /turbovnc_${TURBOVNC_VERSION}_amd64.deb
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    /turbovnc_${TURBOVNC_VERSION}_amd64.deb && \
-    rm turbovnc_${TURBOVNC_VERSION}_amd64.deb && \
-    rm -rf /var/lib/apt/lists/*
+    /turbovnc_${TURBOVNC_VERSION}_amd64.deb \
+  && rm turbovnc_${TURBOVNC_VERSION}_amd64.deb \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && \
-    apt-get install -y lxde-common && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    lxde-common \
+  && rm -rf /var/lib/apt/lists/*
 
 # RUN echo -e "no-remote-connections\n\
 # no-httpd\n\
@@ -168,7 +168,7 @@ ENV PATH "$PATH:/opt/VirtualGL/bin:/opt/TurboVNC/bin"
 
 # Node
 RUN apt-get install -y software-properties-common \
-&& curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-&& apt-get install -y nodejs \
-&& curl -L https://www.npmjs.com/install.sh | sh \
-&& npm install -g yarn
+  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+  && apt-get install -y nodejs \
+  && curl -L https://www.npmjs.com/install.sh | sh \
+  && npm install -g yarn

--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -107,39 +107,29 @@ RUN wget https://xpra.org/xorg.conf \
 RUN git clone https://github.com/novnc/noVNC.git
 RUN cd /noVNC/utils && git clone https://github.com/novnc/websockify.git
 
-# VirtualGL
-COPY ./gpu/virtualgl_${VIRTUALGL_VERSION}_amd64.deb /
-RUN apt-get update && apt-get install -y \
-    libegl1-mesa:amd64
-RUN apt-get update && dpkg -i /virtualgl_${VIRTUALGL_VERSION}_amd64.deb \
-  && rm /virtualgl_${VIRTUALGL_VERSION}_amd64.deb
+# VirtualGL and TurboVNC
+COPY ./gpu/virtualgl_${VIRTUALGL_VERSION}_amd64.deb ./gpu/virtualgl32_${VIRTUALGL_VERSION}_amd64.deb ./gpu/turbovnc_${TURBOVNC_VERSION}_amd64.deb /
 
-COPY ./gpu/virtualgl32_${VIRTUALGL_VERSION}_amd64.deb /
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
     libxtst6:i386 \
     libxv1:i386 \
     libglu1-mesa:i386 \
-    libegl1-mesa:i386
-RUN apt-get update && dpkg -i /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
-  && rm /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
+    libegl1-mesa:i386 \
+    libegl1-mesa:amd64
+
+RUN apt-get update && dpkg -i /virtualgl_${VIRTUALGL_VERSION}_amd64.deb /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
+  && rm /virtualgl_${VIRTUALGL_VERSION}_amd64.deb /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
   && chmod u+s /usr/lib/libvglfaker.so \
   && chmod u+s /usr/lib/libdlfaker.so \
   && chmod u+s /usr/lib32/libvglfaker.so \
   && chmod u+s /usr/lib32/libdlfaker.so \
   && chmod u+s /usr/lib/i386-linux-gnu/libvglfaker.so \
-  && chmod u+s /usr/lib/i386-linux-gnu/libdlfaker.so 
-
-# TurboVNC
-COPY ./gpu/turbovnc_${TURBOVNC_VERSION}_amd64.deb /
-
-#RUN apt-get update && dpkg -i /turbovnc_${TURBOVNC_VERSION}_amd64.deb && \
-#    rm /turbovnc_${TURBOVNC_VERSION}_amd64.deb
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+  && chmod u+s /usr/lib/i386-linux-gnu/libdlfaker.so \
+  && apt-get update && apt-get install -y --no-install-recommends \
     /turbovnc_${TURBOVNC_VERSION}_amd64.deb \
   && rm turbovnc_${TURBOVNC_VERSION}_amd64.deb \
   && rm -rf /var/lib/apt/lists/*
-  
+
 # RUN echo -e "no-remote-connections\n\
 # no-httpd\n\
 # no-x11-tcp-connections\n\

--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -71,21 +71,6 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN mkdir ~/.gazebo && touch ~/.gazebo/gui.ini
 
-# websocket server dependency
-RUN pip3 install websocket_server posix-ipc django==4.1.7 djangorestframework==3.13.1 django-webpack-loader==1.5.0 django-cors-headers==3.14.0
-RUN python3.10 -m pip install websockets asyncio
-
-# pip install dependencies
-RUN python3.10 -m pip install pylint transitions pydantic websocket-client opencv-python
-
-# Install Python 3 pip build dependencies first
-RUN python3.10 -m pip install --upgrade pip wheel setuptools
-
-# Python 3 dependencies installed by pip
-RUN python3.10 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-    matplotlib==3.0.* numpy nunavut==1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-    pyyaml requests serial six toml psutil pyulog wheel onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
-
 # Install VNC
 # Xorg segfault error mitigation
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -144,3 +129,17 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y nodejs \
   && curl -L https://www.npmjs.com/install.sh | sh \
   && npm install -g yarn
+
+# Install Python 3 pip build dependencies first
+RUN python3.10 -m pip install --upgrade pip wheel setuptools
+
+# pip install dependencies
+RUN python3.10 -m pip install \
+    pylint transitions pydantic websocket-client opencv-python \
+    argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+    matplotlib==3.0.* numpy nunavut==1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+    pyyaml requests serial six toml psutil pyulog wheel onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
+
+# websocket server dependency
+RUN python3.10 -m pip install websocket_server posix-ipc django==4.1.7 djangorestframework==3.13.1 \
+    django-webpack-loader==1.5.0 django-cors-headers==3.14.0 websockets asyncio

--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.8.0-base-ubuntu22.04
 # Make all NVIDIA GPUS visible
 ARG NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES all
-ENV VISRTUALGL_VERSION=3.0.2
+ENV VIRTUALGL_VERSION=3.0.2
 ENV TURBOVNC_VERSION=3.0.3
 
 # Setup NON INTERACTIVE ENVIRONMENT
@@ -35,23 +35,21 @@ RUN apt-get update && apt-get install -y \
   apt-utils \
   build-essential \
   git curl wget cmake \
-  vim \
+  nano vim \
   gnupg \
   lsb-release \
   sudo \
   net-tools \
   && rm -rf /var/lib/apt/lists/* 
 
-RUN apt-get update && apt-get install -y alsa-utils alsa-oss
-  
 # Install ROS2 and ROS packages
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
   && apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-ros-base \
-    ros-${ROS_DISTRO}-desktop \
     ros-${ROS_DISTRO}-xacro \
     ros-${ROS_DISTRO}-joint-state-publisher \
+    ros-${ROS_DISTRO}-rviz2 \
     python3-colcon-common-extensions \
     python3-pip python3-rosdep python3-vcstool \
     python3-argcomplete \
@@ -59,11 +57,6 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o 
   && rm -rf /var/lib/apt/lists/*
 # Source ros humble
 RUN echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc
-
-# Install RVIZ2
-RUN apt-get update && apt-get install -y \
-    ros-${ROS_DISTRO}-rviz2 \
-  && rm -rf /var/lib/apt/lists/*
 
 # Install Gazebo 11
 RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
@@ -98,19 +91,13 @@ RUN python3.10 -m pip install argparse argcomplete coverage cerberus empy jinja2
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dbus-x11 \
     libdbus-c++-1-0v5 \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
     xvfb xauth xfonts-base xkb-data x11-xkb-utils \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get --no-install-recommends install -y \
     x11vnc \
     xterm \
     xserver-xorg-video-dummy \
     x11-apps \
-  && apt-get -y autoremove \
-  && apt-get clean autoclean \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
   && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN wget https://xpra.org/xorg.conf \
@@ -121,20 +108,20 @@ RUN git clone https://github.com/novnc/noVNC.git
 RUN cd /noVNC/utils && git clone https://github.com/novnc/websockify.git
 
 # VirtualGL
-COPY ./gpu/virtualgl_${VISRTUALGL_VERSION}_amd64.deb /
+COPY ./gpu/virtualgl_${VIRTUALGL_VERSION}_amd64.deb /
 RUN apt-get update && apt-get install -y \
     libegl1-mesa:amd64
-RUN apt-get update && dpkg -i /virtualgl_${VISRTUALGL_VERSION}_amd64.deb \
-  && rm /virtualgl_${VISRTUALGL_VERSION}_amd64.deb
+RUN apt-get update && dpkg -i /virtualgl_${VIRTUALGL_VERSION}_amd64.deb \
+  && rm /virtualgl_${VIRTUALGL_VERSION}_amd64.deb
 
-COPY ./gpu/virtualgl32_${VISRTUALGL_VERSION}_amd64.deb /
+COPY ./gpu/virtualgl32_${VIRTUALGL_VERSION}_amd64.deb /
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
     libxtst6:i386 \
     libxv1:i386 \
     libglu1-mesa:i386 \
     libegl1-mesa:i386
-RUN apt-get update && dpkg -i /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb \
-  && rm /virtualgl32_${VISRTUALGL_VERSION}_amd64.deb \
+RUN apt-get update && dpkg -i /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
+  && rm /virtualgl32_${VIRTUALGL_VERSION}_amd64.deb \
   && chmod u+s /usr/lib/libvglfaker.so \
   && chmod u+s /usr/lib/libdlfaker.so \
   && chmod u+s /usr/lib32/libvglfaker.so \

--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -135,10 +135,10 @@ RUN python3.10 -m pip install --upgrade pip wheel setuptools
 
 # pip install dependencies
 RUN python3.10 -m pip install \
-    pylint transitions pydantic websocket-client opencv-python \
-    argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+    pylint transitions pydantic websocket-client \
+    argparse coverage cerberus empy jinja2 kconfiglib \
     matplotlib==3.0.* numpy nunavut==1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-    pyyaml requests serial six toml psutil pyulog wheel onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
+    pyyaml requests serial six toml psutil onnxruntime Pillow opencv-python==4.5.5.64 netron seaborn
 
 # websocket server dependency
 RUN python3.10 -m pip install websocket_server posix-ipc django==4.1.7 djangorestframework==3.13.1 \

--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -139,11 +139,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     /turbovnc_${TURBOVNC_VERSION}_amd64.deb \
   && rm turbovnc_${TURBOVNC_VERSION}_amd64.deb \
   && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
-    lxde-common \
-  && rm -rf /var/lib/apt/lists/*
-
+  
 # RUN echo -e "no-remote-connections\n\
 # no-httpd\n\
 # no-x11-tcp-connections\n\
@@ -154,8 +150,7 @@ RUN apt-get update && apt-get install -y \
 ENV PATH "$PATH:/opt/VirtualGL/bin:/opt/TurboVNC/bin"
 
 # Node
-RUN apt-get install -y software-properties-common \
-  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y nodejs \
   && curl -L https://www.npmjs.com/install.sh | sh \
   && npm install -g yarn


### PR DESCRIPTION
https://github.com/JdeRobot/RoboticsInfrastructure/issues/280
Helps reduce base (dependencies_humble) size from 6.8 GBs to 5.3 GBs

Here's the list of changes made:

- Made code styling uniform, easier to read and extend
- Removed packages like alsa-utils alsa-oss lxde-common (not needed)
- Removed ros-humble-desktop, instead use ros-humble-ros-base (decreases the size)
- Clubbed apt installs together to reduce the number of layers and decrease the size
- Restructured Python dependency list and put it at the bottom, since these are likely to have additions in the future, having them at the bottom will help to use the docker cache for system dependencies more effectively.
- Removed duplicate pip installs