### PR TITLE
rosdep install fix

### DIFF
--- a/scripts/mini_RADI/Dockerfile.mini_humble
+++ b/scripts/mini_RADI/Dockerfile.mini_humble
@@ -14,7 +14,7 @@ RUN mv /opt/jderobot/jderobot_drones /home/ws/src/
 
 # Compiling and sourcing the workspace
 WORKDIR /home/ws
-RUN rosdep install --from-paths src --ignore-src -r --rosdistro humble -y
+RUN /bin/bash -c "source /home/drones_ws/install/setup.bash; rosdep install --from-paths src --ignore-src -r --rosdistro humble -y"
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build --symlink-install"
 RUN echo 'source /home/ws/install/setup.bash' >> ~/.bashrc
 


### PR DESCRIPTION
If drone_ws isn't sourced, then rosdep starts looking for aerostack packages in apt.