### PR TITLE
Error in adding exercise.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ websocket-client==0.57.0
 pydiscourse==0.9.0
 django-taggit-autosuggest==0.3.8
 pillow==10.2.0
-
+pylint==2.17.4
 setuptools==65.5.1  # This should be removed after going to python 3.9
 
 djangorestframework==3.13.1


### PR DESCRIPTION
I was getting error while adding exercise which I discussed in [2471](https://github.com/JdeRobot/RoboticsAcademy/issues/2471). I have added pylint==2.17.4 in requirements.txt which solves the error while running python3 manage.py.