### PR TITLE
Replaced base image from cuda to opengl

### DIFF
--- a/scripts/mini_RADI/Dockerfile.dependencies_humble
+++ b/scripts/mini_RADI/Dockerfile.dependencies_humble
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-base-ubuntu22.04
+FROM nvidia/opengl:1.2-glvnd-runtime-ubuntu22.04
 
 # Make all NVIDIA GPUS visible
 ARG NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
fixes #2516 
![image](https://github.com/JdeRobot/RoboticsAcademy/assets/40732709/c04589a0-a264-4b77-9422-b9d24a91e9f1)
