### PR TITLE
[miniRADI] Change robotics-academy to robotics-backend

### DIFF
--- a/scripts/mini_RADI/build.sh
+++ b/scripts/mini_RADI/build.sh
@@ -124,4 +124,4 @@ docker build --no-cache -f $DOCKERFILE \
   --build-arg RAM=$RAM \
   --build-arg ROS_DISTRO=$ROS_DISTRO \
   --build-arg IMAGE_TAG=$IMAGE_TAG \
-  -t jderobot/robotics-academy:$IMAGE_TAG .
+  -t jderobot/robotics-backend:$IMAGE_TAG .


### PR DESCRIPTION
Change docker creation name from robotics-academy/ to robotics-backend/ to match the new naming scheme.
Resolves #2628