### PR TITLE
Fixes broken links in Basic Computer Vision documentation

### DIFF
--- a/_pages/exercises/ComputerVision/basic_computer_vision.md
+++ b/_pages/exercises/ComputerVision/basic_computer_vision.md
@@ -88,13 +88,13 @@ The Hough transform must be applied to the image. The Hough Transform is a techn
 
 ## Hints
 
-[Color space conversion](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.html)
+[Color space conversion](https://opencv24-python-tutorials.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.html)
 
-[Simple thresholding, Adaptive thresholding, Otsu’s thresholding](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_thresholding/py_thresholding.html)
+[Simple thresholding, Adaptive thresholding, Otsu’s thresholding](https://opencv24-python-tutorials.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_thresholding/py_thresholding.html)
 
-[Smoothing Images](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_filtering/py_filtering.html)
+[Smoothing Images](https://opencv24-python-tutorials.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_filtering/py_filtering.html)
 
-[Contour Features](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.html)
+[Contour Features](https://opencv24-python-tutorials.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.html)
 
 
 


### PR DESCRIPTION
**Issue:**

- Some links in the Basic Computer Vision documentation were broken.
- The previous links pointed to https://opencv-python-tutroals.readthedocs.io/, which is no longer active.

**Fix:**

- Replaced outdated links with the correct, active ones from https://opencv24-python-tutorials.readthedocs.io/
- Verified that all new links work as expected.

**Screenshots (Before & After):**

![BrokenLinks](https://github.com/user-attachments/assets/0b9805db-6861-457f-9504-dc9b7ccfe369)

![Active](https://github.com/user-attachments/assets/5f7a9be1-0fdc-460c-a4e7-df142e0a5e82)


