### PR TITLE
feat: add copy button to code snippets

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,4 +2,7 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 <link rel="icon" type="image/png" href="/assets/images/logo.png" sizes="16x16">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <!-- end custom head snippets -->
+
+<script src="{{ '/assets/js/custom/copy-code.js' | relative_url }}"></script>

--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -556,3 +556,35 @@ a.reversefootnote {
     position: static;
   }
 }
+
+/*
+    Copy code button
+    ========================================================================== */
+
+.copy-code-button {
+  position: absolute;
+  right: 0.5em;
+  top: 0.5em;
+  padding: 0.5em;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 3px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.3s;
+  
+  &:hover {
+    opacity: 1;
+    background-color: #e9ecef;
+  }
+  
+  i {
+    font-size: 1em;
+    color: #666;
+  }
+}
+
+pre {
+  position: relative;
+  padding-top: 2.5em;
+}

--- a/assets/js/custom/copy-code.js
+++ b/assets/js/custom/copy-code.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const codeBlocks = document.querySelectorAll('pre');
+  
+    codeBlocks.forEach((codeBlock) => {
+      const copyButton = document.createElement('button');
+      copyButton.className = 'copy-code-button';
+      copyButton.type = 'button';
+      copyButton.innerHTML = '<i class="fas fa-copy"></i>';
+      
+      codeBlock.parentNode.style.position = 'relative';
+      codeBlock.parentNode.appendChild(copyButton);
+  
+      copyButton.addEventListener('click', function() {
+        const code = codeBlock.querySelector('code').innerText;
+        navigator.clipboard.writeText(code).then(() => {
+          copyButton.innerHTML = '<i class="fas fa-check"></i>';
+          setTimeout(() => {
+            copyButton.innerHTML = '<i class="fas fa-copy"></i>';
+          }, 2000);
+        });
+      });
+    });
+  });


### PR DESCRIPTION
**Result**

![image](https://github.com/user-attachments/assets/6ca363d6-9774-425a-b9cc-741f83a7b65e)

**Note**: the feature only works in secure contexts (HTTPS) or on `localhost`.
So it won't work on `127.0.0.1`, which Jekyll shows when run.


closes #3024 