### PR TITLE
update incorrect link and folder path

### DIFF
--- a/exercises/templates/exercises/basic_computer_vision/exercise.html
+++ b/exercises/templates/exercises/basic_computer_vision/exercise.html
@@ -6,9 +6,9 @@
 
 {% block react-content %}
     {% if deployment %}
-        {% react_component exercise/rescue_people/BasicComputerVisionRR %}
+        {% react_component exercise/basic_computer_vision/BasicComputerVisionRR %}
             {% react_component components/containers/MaterialBox id="exercise-container" %}
-            {% react_component components/common/MainAppBar exerciseName="Basic Computer Vision" url="https://jderobot.github.io/RoboticsAcademy/exercises/Drones/basic_computer_vision"%} 
+            {% react_component components/common/MainAppBar exerciseName="Basic Computer Vision" url="https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/basic_computer_vision"%} 
             {% end_react_component %}
             {% react_component components/containers/MaterialBox id="content" %}
                 {% react_component components/containers/MaterialBox id="content-exercise" %}
@@ -19,7 +19,7 @@
                         {% react_component components/visualizers/VncConsoleViewer%}{% end_react_component %}
                         {% end_react_component%}
                         {% react_component components/containers/FlexContainer%} 
-                            {% react_component exercise/rescue_people/SpecificBasicComputerVision %} {% end_react_component %}
+                            {% react_component exercise/basic_computer_vision/SpecificBasicComputerVision %} {% end_react_component %}
                             {% react_component components/visualizers/Camera%}{% end_react_component %}
                         {% end_react_component %}
                 {% end_react_component %}


### PR DESCRIPTION
Expected Behavior :
Clicking the Education icon should redirect to the correct [JdeRobot](https://jderobot.github.io/RoboticsAcademy/exercises/ComputerVision/basic_computer_vision) page.

The Components panel should properly reference the `basic_computer_vision` folder.

Related Issue
Closes #3106 

Checklist
-  Fixes broken education link
- Updates folder name from `rescue_people` to `basic_computer_vision`
