### PR TITLE
fix: add automatic Yarn installation check in develop_academy.sh

### DIFF
--- a/scripts/develop_academy.sh
+++ b/scripts/develop_academy.sh
@@ -95,8 +95,36 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Prepare yarn 
-if ! command -v yarn --version &> /dev/null; then
-  npm install --global yarn
+if ! command -v yarn &> /dev/null; then
+  echo "Yarn is not installed. Installing Yarn..."
+  
+  # Check if npm exists or not
+  if command -v npm &> /dev/null; then
+    npm install --global yarn
+  else
+    echo "npm is not installed. Installing Node.js and npm first..."
+    
+    # Detect OS and install npm and node.js accordingly
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+      sudo apt-get install -y nodejs
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      if command -v brew &> /dev/null; then
+        brew install node
+      else
+        echo "Homebrew not found. Please install Yarn manually: https://yarnpkg.com/getting-started/install"
+        exit 1
+      fi
+    else
+      echo "Unsupported OS. Please install Yarn manually: https://yarnpkg.com/getting-started/install"
+      exit 1
+    fi
+    
+    npm install --global yarn
+  fi
+  echo "Yarn installed successfully."
+else
+  echo "Yarn is already installed."
 fi
 
 # Prepare the commons zip file


### PR DESCRIPTION
This commit resolves issue #3314.

It adds checks in the develop_academy.sh script to verify whether Yarn is installed. 
If Yarn is missing, the script now installs Node.js and npm (if needed), detects 
the user's operating system (Linux or macOS), and installs Yarn accordingly.

This change improves the setup process by making it more robust and beginner-friendly,
reducing setup errors for new contributors and ensuring compatibility across platforms.

If yarn is not installed-:
<img width="660" height="183" alt="Screenshot 2025-11-06 at 10 33 08 AM" src="https://github.com/user-attachments/assets/1cfc5107-f40b-43a2-ae7e-ddf7a99c0963" />

If yarn is already installed-:
<img width="624" height="77" alt="Screenshot 2025-11-06 at 10 27 45 AM" src="https://github.com/user-attachments/assets/f43225ed-e1f7-4a8f-b63d-7fc8142678b3" />