### PR TITLE
Save search bar and filter state using sessionStorage (fixes #3257)

### DIFF
--- a/react_frontend/src/components/buttons/Search.tsx
+++ b/react_frontend/src/components/buttons/Search.tsx
@@ -13,6 +13,7 @@ import {
 import { useHomepage } from "Contexts/HomepageContext";
 import { useState, useEffect } from "react";
 import { useAcademyTheme } from "Contexts/AcademyThemeContext";
+import { Filters } from "src/types/exercises";
 
 // SessionStorage keys
 const FILTER_STORAGE_KEY = "ra_home_filters_v1";
@@ -89,7 +90,7 @@ const StyledMenu = styled(Menu)(
   })
 );
 
-// Filter persistance structure
+// Filter persistence structure
 type FilterState = {
   tags: boolean;
   description: boolean;
@@ -102,16 +103,22 @@ const DEFAULT_FILTER_STATE: FilterState = {
   status: false,
 };
 
-// Componente FilterMenu
+const filtersFromState = (state: FilterState): Filters[] => {
+  const list: Filters[] = ["name"]; // name is always active
+  if (state.tags) list.push("tags");
+  if (state.description) list.push("description");
+  if (state.status) list.push("status");
+  return list;
+};
+
 const FilterMenu = () => {
-  const { appendFilterItem } = useHomepage();
+  const { appendFilterItem, setFilterItemsList } = useHomepage();
   const theme = useAcademyTheme();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open: boolean = Boolean(anchorEl);
 
-  const [filterState, setFilterState] = useState<FilterState>(
-    DEFAULT_FILTER_STATE
-  );
+  const [filterState, setFilterState] =
+    useState<FilterState>(DEFAULT_FILTER_STATE);
 
   // Restore session filter state
   useEffect(() => {
@@ -119,7 +126,7 @@ const FilterMenu = () => {
 
     try {
       const raw = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
-      if (!raw) return; 
+      if (!raw) return;
 
       const parsed = JSON.parse(raw) as Partial<FilterState>;
       const persisted: FilterState = {
@@ -138,17 +145,11 @@ const FilterMenu = () => {
       };
 
       setFilterState(persisted);
-
-      // Sync context with persisted values
-      (["tags", "description", "status"] as const).forEach((key) => {
-        if (persisted[key] !== DEFAULT_FILTER_STATE[key]) {
-          appendFilterItem(key);
-        }
-      });
+      setFilterItemsList(filtersFromState(persisted));
     } catch (err) {
       console.error("Failed to restore filter state", err);
     }
-  }, [appendFilterItem]);
+  }, [setFilterItemsList]);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -170,21 +171,19 @@ const FilterMenu = () => {
         [name]: !prev[name],
       };
 
-      if (typeof window !== "undefined") {
-        try {
-          window.sessionStorage.setItem(
-            FILTER_STORAGE_KEY,
-            JSON.stringify(updated)
-          );
-        } catch (err) {
-          console.error("Failed to save filter state", err);
-        }
+      try {
+        window.sessionStorage.setItem(
+          FILTER_STORAGE_KEY,
+          JSON.stringify(updated)
+        );
+      } catch (err) {
+        console.error("Failed to save filter state", err);
       }
 
       return updated;
     });
 
-    appendFilterItem(name);
+    appendFilterItem(name as Filters);
   };
 
   return (
@@ -246,14 +245,13 @@ const FilterMenu = () => {
   );
 };
 
-// Componente principal SearchBar
 const SearchBar = () => {
   const { setSearchBarText } = useHomepage();
   const theme = useAcademyTheme();
 
   const [searchValue, setSearchValue] = useState<string>("");
-  
-  // Restore session filter state
+
+  // Restore session search text
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -261,7 +259,6 @@ const SearchBar = () => {
       const saved = window.sessionStorage.getItem(SEARCH_STORAGE_KEY);
       if (saved) {
         setSearchValue(saved);
-
         setSearchBarText(saved.toLowerCase());
       }
     } catch (err) {
@@ -277,12 +274,10 @@ const SearchBar = () => {
     const lowerCase = value.toLowerCase();
     setSearchBarText(lowerCase);
 
-    if (typeof window !== "undefined") {
-      try {
-        window.sessionStorage.setItem(SEARCH_STORAGE_KEY, value);
-      } catch (err) {
-        console.error("Failed to save search text", err);
-      }
+    try {
+      window.sessionStorage.setItem(SEARCH_STORAGE_KEY, value);
+    } catch (err) {
+      console.error("Failed to save search text", err);
     }
   };
 

--- a/react_frontend/src/components/buttons/Search.tsx
+++ b/react_frontend/src/components/buttons/Search.tsx
@@ -11,8 +11,12 @@ import {
   MenuItem,
 } from "@mui/material";
 import { useHomepage } from "Contexts/HomepageContext";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAcademyTheme } from "Contexts/AcademyThemeContext";
+
+// SessionStorage keys
+const FILTER_STORAGE_KEY = "ra_home_filters_v1";
+const SEARCH_STORAGE_KEY = "ra_home_search_v1";
 
 // Estilos
 const Search = styled("div")(({ roundness }: { roundness: number }) => ({
@@ -85,12 +89,66 @@ const StyledMenu = styled(Menu)(
   })
 );
 
+// Filter persistance structure
+type FilterState = {
+  tags: boolean;
+  description: boolean;
+  status: boolean;
+};
+
+const DEFAULT_FILTER_STATE: FilterState = {
+  tags: true,
+  description: false,
+  status: false,
+};
+
 // Componente FilterMenu
 const FilterMenu = () => {
   const { appendFilterItem } = useHomepage();
   const theme = useAcademyTheme();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open: boolean = Boolean(anchorEl);
+
+  const [filterState, setFilterState] = useState<FilterState>(
+    DEFAULT_FILTER_STATE
+  );
+
+  // Restore session filter state
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    try {
+      const raw = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
+      if (!raw) return; 
+
+      const parsed = JSON.parse(raw) as Partial<FilterState>;
+      const persisted: FilterState = {
+        tags:
+          typeof parsed.tags === "boolean"
+            ? parsed.tags
+            : DEFAULT_FILTER_STATE.tags,
+        description:
+          typeof parsed.description === "boolean"
+            ? parsed.description
+            : DEFAULT_FILTER_STATE.description,
+        status:
+          typeof parsed.status === "boolean"
+            ? parsed.status
+            : DEFAULT_FILTER_STATE.status,
+      };
+
+      setFilterState(persisted);
+
+      // Sync context with persisted values
+      (["tags", "description", "status"] as const).forEach((key) => {
+        if (persisted[key] !== DEFAULT_FILTER_STATE[key]) {
+          appendFilterItem(key);
+        }
+      });
+    } catch (err) {
+      console.error("Failed to restore filter state", err);
+    }
+  }, [appendFilterItem]);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -100,9 +158,33 @@ const FilterMenu = () => {
     setAnchorEl(null);
   };
 
-  const handleFilterList = (e: any) => {
-    const item = e.target.name;
-    appendFilterItem(item);
+  // Toggle and persist filter values
+  const handleFilterCheckboxChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const name = e.target.name as keyof FilterState;
+
+    setFilterState((prev) => {
+      const updated: FilterState = {
+        ...prev,
+        [name]: !prev[name],
+      };
+
+      if (typeof window !== "undefined") {
+        try {
+          window.sessionStorage.setItem(
+            FILTER_STORAGE_KEY,
+            JSON.stringify(updated)
+          );
+        } catch (err) {
+          console.error("Failed to save filter state", err);
+        }
+      }
+
+      return updated;
+    });
+
+    appendFilterItem(name);
   };
 
   return (
@@ -127,29 +209,36 @@ const FilterMenu = () => {
         checkboxColor={theme.palette.text!}
         roundness={theme.roundness!}
       >
+        {/* Name always active and not persisted */}
         <MenuItem>
           <Checkbox defaultChecked disabled size="small" name="name" />
           Name
         </MenuItem>
         <MenuItem>
           <Checkbox
-            defaultChecked
             size="small"
-            onClick={handleFilterList}
             name="tags"
+            checked={filterState.tags}
+            onChange={handleFilterCheckboxChange}
           />
           Tags
         </MenuItem>
         <MenuItem>
           <Checkbox
             size="small"
-            onClick={handleFilterList}
             name="description"
+            checked={filterState.description}
+            onChange={handleFilterCheckboxChange}
           />
           Description
         </MenuItem>
         <MenuItem>
-          <Checkbox size="small" onClick={handleFilterList} name="status" />
+          <Checkbox
+            size="small"
+            name="status"
+            checked={filterState.status}
+            onChange={handleFilterCheckboxChange}
+          />
           Status
         </MenuItem>
       </StyledMenu>
@@ -162,9 +251,39 @@ const SearchBar = () => {
   const { setSearchBarText } = useHomepage();
   const theme = useAcademyTheme();
 
+  const [searchValue, setSearchValue] = useState<string>("");
+  
+  // Restore session filter state
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    try {
+      const saved = window.sessionStorage.getItem(SEARCH_STORAGE_KEY);
+      if (saved) {
+        setSearchValue(saved);
+
+        setSearchBarText(saved.toLowerCase());
+      }
+    } catch (err) {
+      console.error("Failed to restore search text", err);
+    }
+  }, [setSearchBarText]);
+
+  // Update sessionStorage + context
   const inputHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const lowerCase = e.target.value.toLowerCase();
+    const value = e.target.value;
+    setSearchValue(value);
+
+    const lowerCase = value.toLowerCase();
     setSearchBarText(lowerCase);
+
+    if (typeof window !== "undefined") {
+      try {
+        window.sessionStorage.setItem(SEARCH_STORAGE_KEY, value);
+      } catch (err) {
+        console.error("Failed to save search text", err);
+      }
+    }
   };
 
   return (
@@ -181,6 +300,7 @@ const SearchBar = () => {
         </SearchIconWrapper>
         <StyledInputBase
           placeholder="Search…"
+          value={searchValue}
           onChange={inputHandler}
           textColor={theme.palette.text!}
           inputProps={{ "aria-label": "search" }}
@@ -192,3 +312,4 @@ const SearchBar = () => {
 };
 
 export default SearchBar;
+

--- a/react_frontend/src/contexts/HomepageContext.tsx
+++ b/react_frontend/src/contexts/HomepageContext.tsx
@@ -7,17 +7,15 @@ export interface HomepageContextType {
   setSearchBarText: (text: string) => void;
   appendFilterItem: (item: Filters) => void;
   getFilterItemsList: () => Filters[];
+  setFilterItemsList: (items: Filters[]) => void;
 }
 
 const HomepageContext = createContext<HomepageContextType>({
-  getSearchBarText: () => {
-    return "";
-  },
+  getSearchBarText: () => "",
   setSearchBarText: () => {},
   appendFilterItem: () => {},
-  getFilterItemsList: () => {
-    return [];
-  },
+  getFilterItemsList: () => [],
+  setFilterItemsList: () => {},
 });
 
 export const useHomepage = () => useContext(HomepageContext);
@@ -34,12 +32,12 @@ export function HomepageProvider({ children }: { children?: ReactNode }) {
   const setSearchBarText = (text: string) => {
     setInputText(text);
   };
+
   const getFilterItemsList = () => filterItemsList;
+
   const appendFilterItem = (item: Filters) => {
-    setFilterItemsList(
-      filterItemsList.includes(item)
-        ? filterItemsList.filter((i) => i !== item)
-        : [...filterItemsList, item]
+    setFilterItemsList((prev) =>
+      prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
     );
   };
 
@@ -50,6 +48,7 @@ export function HomepageProvider({ children }: { children?: ReactNode }) {
         setSearchBarText,
         appendFilterItem,
         getFilterItemsList,
+        setFilterItemsList,
       }}
     >
       {children}
@@ -58,3 +57,4 @@ export function HomepageProvider({ children }: { children?: ReactNode }) {
 }
 
 export default HomepageContext;
+


### PR DESCRIPTION
This PR implements sessionStorage-based persistence for the search bar and filter menu (fixes #3257).

### What’s improved
- Filters (Tags / Description / Status) now remain active when:
  - Reloading the exercises page
  - Navigating into an exercise and back
- Search bar text is also restored during the same browser session
- Both filter state and search text reset automatically when the browser/tab is closed