### PR TITLE
fix: correct broken link for digit classifier exercise

### DIFF
--- a/_pages/exercises/ComputerVision/computer_vision_section.md
+++ b/_pages/exercises/ComputerVision/computer_vision_section.md
@@ -48,7 +48,7 @@ feature_row:
     alt: "Digit Classifier"
     title: "Digit Classifier"
     excerpt: "Classify digits in real time using your own deep learning model."
-    url: "/exercises/ComputerVision/dl_digit_classifier"
+    url: "/exercises/ComputerVision/digit_classification"
     status: "prototype"
     order: 0;
     version: "v3.2"


### PR DESCRIPTION
### Description
This PR fixes the broken link for the "Digit Classifier" exercise in the Computer Vision section, as reported in issue #3335.

### Changes
- Updated the URL in `_pages/exercises/ComputerVision/computer_vision_section.md`
- Changed `dl_digit_classifier` (404 Not Found) -> `digit_classification` (Correct Page)

### Related Issue
Fixes #3335

This is my first contribution to this repository. Please let me know if any other changes are required!