### PR TITLE
fix: Car Junction exercise bugs for Gazebo Harmonic

### DIFF
--- a/exercises/static/exercises/car_junction/python_template/ros2_humble/HAL.py
+++ b/exercises/static/exercises/car_junction/python_template/ros2_humble/HAL.py
@@ -77,3 +77,15 @@ def getLidarData():
 
 def setV(velocity):
     motor_node.sendV(float(velocity))
+
+
+def setW(angular):
+    motor_node.sendW(float(angular))
+
+
+def getV():
+    return motor_node.getV()
+
+
+def getW():
+    return motor_node.getW()

--- a/exercises/static/exercises/car_junction/python_template/ros2_humble/WebGUI.py
+++ b/exercises/static/exercises/car_junction/python_template/ros2_humble/WebGUI.py
@@ -58,7 +58,7 @@ class WebGUI(MeasuringThreadingGUI):
 
         if np.any(self.front_image):
             _, encoded_front_image = cv2.imencode(".JPEG", self.front_image)
-            b64_left = base64.b64encode(encoded_front_image).decode("utf-8")
+            b64_front = base64.b64encode(encoded_front_image).decode("utf-8")
             shape_front = self.front_image.shape
         else:
             b64_front = None
@@ -74,7 +74,7 @@ class WebGUI(MeasuringThreadingGUI):
 
     def setFrontImage(self, image):
         with self.image_lock:
-            self.left_image = image
+            self.front_image = image
 
 host = "ws://127.0.0.1:2303"
 gui = WebGUI(host)


### PR DESCRIPTION
Fixes #3231

## Changes:
- Added missing `setW()`, `getV()`, `getW()` functions in HAL.py
- Fixed variable name bug in WebGUI.py (`b64_left` → `b64_front`, `self.left_image` → `self.front_image`)
- Fixed undefined `pkg_share` variable in launch file

## Tested:
- All HAL functions for motor control
- WebGUI image streaming
- Launch file syntax
