### PR TITLE
docs: clarify OpenCV BGR compatibility in Follow Line exercise #3111

### DIFF
--- a/_pages/exercises/AutonomousCars/follow_line.md
+++ b/_pages/exercises/AutonomousCars/follow_line.md
@@ -89,7 +89,7 @@ This exercise now supports ROS 2-native implementation in addition to the origin
 
 * `import HAL` - to import the HAL (Hardware Abstraction Layer) library class. This class contains the functions that send and receive information to and from the Hardware (Gazebo).
 * `import WebGUI` - to import the WebGUI (Web Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
-* `HAL.getImage()` - to get the image (BGR8).
+* `HAL.getImage()` - to get the image (BGR8). *Note: This returns a standard OpenCV-compatible image array.*
 * `HAL.setV(velocity)` - to set the linear speed.
 * `HAL.setW(velocity)` - to set the angular velocity.
 * `WebGUI.showImage(image)` - allows you to view a debug image or with relevant information.
@@ -98,7 +98,7 @@ This exercise now supports ROS 2-native implementation in addition to the origin
 
 * `#include "HAL.hpp"` - to import the HAL (Hardware Abstraction Layer) library class. This class contains the functions that send and receive information to and from the Hardware (Gazebo).
 * `#include "WebGUI.hpp"` - to import the WebGUI (Web Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
-* `HAL::get_image();` - to get the image (cv::Mat).
+* `HAL::get_image();` - to get the image (cv::Mat). *Note: Returns an OpenCV BGR image.*
 * `HAL::set_v(velocity);` - to set the linear speed.
 * `HAL::set_w(velocity);` - to set the angular velocity.
 * `WebGUI::show_image(image);` - allows you to view a debug image (cv::Mat) or with relevant information.


### PR DESCRIPTION
This PR addresses Issue #3111 by adding a technical note to the Follow Line exercise documentation. I have clarified that the API returns images in BGR format for both Python and C++ implementations to help students avoid common OpenCV orientation errors.