### PR TITLE
Docs: Add inline documentation to backend exercise API files

### DIFF
--- a/exercises/error_handler.py
+++ b/exercises/error_handler.py
@@ -1,3 +1,10 @@
+"""
+Utilities for request validation and API error handling.
+
+This module provides a decorator to wrap API views with
+common parameter checks and consistent error responses.
+"""
+
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 import binascii
@@ -19,25 +26,47 @@ CUSTOM_EXCEPTIONS = (
 
 
 def error_wrapper(type: str, param: list[str | tuple] = []):
+    """
+    Decorator for API views with parameter validation and error handling.
+
+    Args:
+        type (str): HTTP method to allow for the view.
+        param (list): Required request parameters or (name, min_length) tuples.
+
+    Returns:
+        function: Wrapped API view.
+    """
     def decorated(func):
         @wraps(func)
         @api_view([type])
         def wrapper(request):
             try:
-                check_parameters(request.data if type == "POST" else request.GET, param)
+                check_parameters(
+                    request.data if type == "POST" else request.GET,
+                    param
+                )
                 return func(request)
             except CUSTOM_EXCEPTIONS as e:
                 print(str(e))
-                return Response({"error": f"{str(e)}"}, status=e.error_code)
+                return Response({"error": str(e)}, status=e.error_code)
             except json.JSONDecodeError as e:
                 print(str(e))
-                return Response({"error": f"Invalid JSON format: {str(e)}"}, status=422)
+                return Response(
+                    {"error": f"Invalid JSON format: {str(e)}"},
+                    status=422
+                )
             except (binascii.Error, ValueError) as e:
                 print(str(e))
-                return Response({"error": f"Invalid B64 format: {str(e)}"}, status=422)
+                return Response(
+                    {"error": f"Invalid B64 format: {str(e)}"},
+                    status=422
+                )
             except Exception as e:
                 print(str(e))
-                return Response({"error": f"An error occurred: {str(e)}"}, status=500)
+                return Response(
+                    {"error": f"An error occurred: {str(e)}"},
+                    status=500
+                )
 
         return wrapper
 
@@ -45,6 +74,16 @@ def error_wrapper(type: str, param: list[str | tuple] = []):
 
 
 def check_parameters(request, param: list[str | tuple]):
+    """
+    Validate required request parameters.
+
+    Args:
+        request: Request data or query parameters.
+        param (list): Required parameters or (name, min_length) tuples.
+
+    Raises:
+        ParameterInvalid: If a parameter is missing or invalid.
+    """
     for p in param:
         min_len = 0
         if type(p) is tuple:
@@ -53,5 +92,5 @@ def check_parameters(request, param: list[str | tuple]):
         if p not in request:
             raise ParameterInvalid(p)
         data = request.get(p)
-        if data == None or len(data) <= min_len:
+        if data is None or len(data) <= min_len:
             raise ParameterInvalid(p)

--- a/exercises/urls.py
+++ b/exercises/urls.py
@@ -1,15 +1,16 @@
-from django.urls import path
+"""
+URL routing for the exercises backend.
 
+Defines API endpoints and maps them to their corresponding views.
+"""
+
+from django.urls import path
 from . import views
 
 urlpatterns = [
     path("get_info/", views.get_info, name="get_info"),
     path("get_exercise_list/", views.get_exercise_list, name="get_exercise_list"),
-    path(
-        "user_code_zip/",
-        views.user_code_zip,
-        name="user_code_zip",
-    ),
+    path("user_code_zip/", views.user_code_zip, name="user_code_zip"),
     path(
         "get_universes_list/",
         views.get_universes_list,

--- a/exercises/views.py
+++ b/exercises/views.py
@@ -1,3 +1,10 @@
+"""
+API views for the exercises backend.
+
+Provides endpoints to retrieve exercise data, user templates,
+and universe configuration information.
+"""
+
 import json
 import os
 from django.conf import settings
@@ -11,11 +18,13 @@ from rest_framework import status
 
 @error_wrapper("GET", ["project_id"])
 def get_info(request):
+    """
+    Retrieve basic information about an exercise.
+    """
     project_id = request.GET.get("project_id")
     project = Exercise.objects.get(exercise_id=project_id)
 
     tools = []
-
     for tool in project.tools.all():
         tools.append(tool.name)
 
@@ -31,6 +40,9 @@ def get_info(request):
 
 @error_wrapper("GET")
 def get_exercise_list(request):
+    """
+    Return a list of all available exercises.
+    """
     project_list = []
     projects = Exercise.objects.all()
 
@@ -50,12 +62,14 @@ def get_exercise_list(request):
 
 @error_wrapper("POST", ["project", "language"])
 def user_code_zip(request):
+    """
+    Return template source files for a given exercise and language.
+    """
     project_id = request.data.get("project")
     language = request.data.get("language")
     project = Exercise.objects.get(exercise_id=project_id)
 
     template = "python_template"
-
     if language == "cpp":
         template = "cpp_template"
 
@@ -64,7 +78,6 @@ def user_code_zip(request):
         f"exercises/static/exercises/{project.exercise_id}/{template}/ros2_humble",
     )
 
-    print(exercise_path)
     files = []
 
     try:
@@ -82,12 +95,16 @@ def user_code_zip(request):
 
     except Exception as e:
         return Response(
-            {"success": False, "message": str(e)}, status=status.HTTP_400_BAD_REQUEST
+            {"success": False, "message": str(e)},
+            status=status.HTTP_400_BAD_REQUEST,
         )
 
 
 @error_wrapper("GET", ["project"])
 def get_universes_list(request):
+    """
+    Return the list of universes associated with an exercise.
+    """
     project_id = request.GET.get("project")
     project = Exercise.objects.get(exercise_id=project_id)
 
@@ -109,6 +126,9 @@ def get_universes_list(request):
 
 @error_wrapper("GET", ["project"])
 def get_docker_universe_data(request):
+    """
+    Retrieve docker and universe configuration for an exercise.
+    """
     name = request.GET.get("universe")
     project_id = request.GET.get("project")
     project = Exercise.objects.get(exercise_id=project_id)
@@ -178,10 +198,4 @@ def get_docker_universe_data(request):
             "tools_config": tools_configuration,
         }
 
-    # Return the list of projects
-    return Response(
-        {
-            "success": True,
-            "universe": config,
-        }
-    )
+    return Response({"success": True, "universe": config})


### PR DESCRIPTION
This PR adds inline documentation and docstrings to active backend API files.

Updated files:
- exercises/error_handler.py
- exercises/urls.py
- exercises/views.py

The changes improve readability and maintainability without modifying behavior.
No exercise solutions or deprecated files were touched.

Addresses #3111.
