### PR TITLE
Fix WebGUI desynchronization in Gazebo Harmonic

### DIFF
--- a/exercises/static/exercises/vacuum_cleaner/python_template/ros2_humble/WebGUI.py
+++ b/exercises/static/exercises/vacuum_cleaner/python_template/ros2_humble/WebGUI.py
@@ -13,7 +13,6 @@ from map import Map
 # Simple HAL check
 try:
     from HAL import getPose3d as hal_getPose3d
-
     HAL_AVAILABLE = True
 except ImportError:
     HAL_AVAILABLE = False
@@ -23,27 +22,34 @@ class ROS2Node(Node):
     def __init__(self):
         super().__init__("gui_data")
         self.pose = None
-        self.pose_lock = threading.Lock()  # Thread safety
+        self.new_pose = False
+        self.pose_lock = threading.Lock()
         self.create_subscription(Odometry, "/odom", self.callback, 10)
 
     def callback(self, msg):
         with self.pose_lock:
             self.pose = msg.pose.pose
+            self.new_pose = True
+
+    def consume_pose(self):
+        with self.pose_lock:
+            if not self.new_pose:
+                return None
+            self.new_pose = False
+            return self.pose
 
     def get_pose3d(self):
         with self.pose_lock:
             if not self.pose:
-
                 class P:
                     x = y = yaw = 0.0
-
                 return P()
 
             import math
-
             q = self.pose.orientation
             yaw = math.atan2(
-                2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z)
+                2 * (q.w * q.z + q.x * q.y),
+                1 - 2 * (q.y * q.y + q.z * q.z),
             )
 
             class Pose3D:
@@ -57,12 +63,12 @@ class WebGUI(MeasuringThreadingGUI):
     def __init__(self, host="ws://127.0.0.1:2303"):
         super().__init__(host)
 
-        # Payload vars
+        # Payload vars (KEEP ORIGINAL PROTOCOL)
         self.payload = {"map": ""}
         self.init_coords = (171, 63)
         self.start_coords = (201, 85.5)
 
-        # Initialize ROS2 components
+        # ROS2 components
         self.ros_node = None
         self.executor = None
         self.executor_thread = None
@@ -70,28 +76,25 @@ class WebGUI(MeasuringThreadingGUI):
         # Auto-detect mode and get pose function
         pose_getter = self._get_pose_function()
         self.map = Map(pose_getter)
+
+        # Start GUI (IMPORTANT)
         self.start()
 
     def _get_pose_function(self):
         """Auto-detect the best pose source"""
-        # Try ROS2 first
         try:
-            # Initialize ROS2 if not already done
             if not rclpy.ok():
                 rclpy.init()
 
-            # Check for topics using a temporary node
             temp_node = rclpy.create_node("temp_topic_checker")
             topics = [name for name, _ in temp_node.get_topic_names_and_types()]
             temp_node.destroy_node()
 
             if "/odom" in topics:
-                # Set up ROS2 node with proper executor
                 self.ros_node = ROS2Node()
                 self.executor = SingleThreadedExecutor()
                 self.executor.add_node(self.ros_node)
 
-                # Start executor in separate thread
                 self.executor_thread = threading.Thread(
                     target=self._ros_spin, daemon=True
                 )
@@ -103,13 +106,11 @@ class WebGUI(MeasuringThreadingGUI):
         except Exception as e:
             print(f"GUI: ROS2 setup failed: {e}")
 
-        # Fallback to HAL
         if HAL_AVAILABLE:
             print("GUI: HAL mode activated")
             return hal_getPose3d
 
-        # Last resort: dummy mode
-        print("GUI: Dummy mode activated - no pose data available")
+        print("GUI: Dummy mode activated")
 
         class DummyPose:
             x = y = yaw = 0.0
@@ -117,27 +118,33 @@ class WebGUI(MeasuringThreadingGUI):
         return lambda: DummyPose()
 
     def _ros_spin(self):
-        """Safe ROS2 spinning in dedicated thread"""
         try:
             self.executor.spin()
         except Exception as e:
             print(f"GUI: ROS2 executor error: {e}")
 
+    # ✅ FIXED: GUI updates synchronized to /odom
     def update_gui(self):
-        """Update GUI with latest robot position"""
+        # Only update GUI when a NEW odom message arrives
+        if self.ros_node:
+            pose = self.ros_node.consume_pose()
+            if pose is None:
+                return
+
         pos = self.map.getRobotCoordinates()
         if pos == self.init_coords:
             pos = self.start_coords
+
         ang = self.map.getRobotAngle()
+
+        # KEEP ORIGINAL MAP STRING FORMAT
         self.payload["map"] = str(pos + ang)
         self.send_to_client(json.dumps(self.payload))
 
     def reset_gui(self):
-        """Reset the map"""
         self.map.reset()
 
     def __del__(self):
-        """Cleanup ROS2 resources"""
         if self.executor:
             self.executor.shutdown()
 

--- a/exercises/static/exercises/vacuum_cleaner/python_template/ros2_humble/WebGUI.py
+++ b/exercises/static/exercises/vacuum_cleaner/python_template/ros2_humble/WebGUI.py
@@ -123,7 +123,7 @@ class WebGUI(MeasuringThreadingGUI):
         except Exception as e:
             print(f"GUI: ROS2 executor error: {e}")
 
-    # ✅ FIXED: GUI updates synchronized to /odom
+    #  FIXED: GUI updates synchronized to /odom
     def update_gui(self):
         # Only update GUI when a NEW odom message arrives
         if self.ros_node:


### PR DESCRIPTION
* Summary
Fixes a progressive desynchronization between the WebGUI and Gazebo Harmonic simulator observed in the Basic Vacuum Cleaner exercise.

* Root cause
WebGUI updates were driven by a wall-clock GUI loop, while Gazebo Harmonic advances using simulation time, causing cumulative lag.

* Fix
Synchronize WebGUI updates with the arrival of new `/odom` messages, ensuring one GUI update per simulation step.

### Scope
- Backend-only change (`WebGUI.py`)
- No frontend or protocol changes
- Backward compatible

Fixes #3330
