### PR TITLE
Make RADI Docker build architecture-aware (fix colcon build on arm64)

### DIFF
--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -295,8 +295,24 @@ RUN apt-get update && \
         libpoco-dev \
       && rm -rf /var/lib/apt/lists/*
 
+# On arm64 (e.g. Apple Silicon), disable parallel colcon builds and LTO
+# to avoid GNU make jobserver failures under amd64 emulation.
+
+ARG TARGETARCH
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        colcon build \
+          --symlink-install \
+          --executor sequential \
+          --cmake-args \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF ; \
+    else \
+        colcon build \
+          --symlink-install \
+          --cmake-args \
+            -DCMAKE_BUILD_TYPE=Release ; \
+    fi
 
 # Install CycloneDDS RMW for ROS 2 Humble to fix cycle time issues in humble-moveit (temporary fix)    
 RUN echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc


### PR DESCRIPTION
This PR makes the RADI Docker build architecture-aware by disabling
parallel colcon builds and LTO when building on arm64.

On Apple Silicon hosts, the amd64 base image runs under QEMU emulation.
In this scenario, parallel colcon builds with LTO enabled can fail with
GNU make jobserver errors when building Aerostack2 (as2_core).

The change preserves existing behavior on amd64.
