### PR TITLE
Update OMPL to 1.7.0

### DIFF
--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -339,4 +339,4 @@ RUN echo "source /home/drones_ws/install/setup.bash" >> ~/.bashrc
 COPY install-ompl-ubuntu.sh /
 WORKDIR /
 RUN chmod u+x install-ompl-ubuntu.sh
-RUN ./install-ompl-ubuntu.sh --github --python
+RUN ./install-ompl-ubuntu.sh --python

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -339,4 +339,4 @@ RUN echo "source /home/drones_ws/install/setup.bash" >> ~/.bashrc
 COPY install-ompl-ubuntu.sh /
 WORKDIR /
 RUN chmod u+x install-ompl-ubuntu.sh
-RUN ./install-ompl-ubuntu.sh --python
+RUN ./install-ompl-ubuntu.sh --github --python

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -95,8 +95,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xterm \
     xserver-xorg-video-dummy \
     x11-apps \
-	&& apt-get -y autoremove \
-	&& apt-get clean autoclean \
+  && apt-get -y autoremove \
+  && apt-get clean autoclean \
   && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN curl -L -o xorg.conf https://xpra.org/xorg.conf || echo "Download failed" \

--- a/scripts/RADI/install-ompl-ubuntu.sh
+++ b/scripts/RADI/install-ompl-ubuntu.sh
@@ -88,10 +88,14 @@ install_ompl()
     cd build/Release
     cmake ../.. -DPYTHON_EXEC=/usr/bin/python${PYTHONV}
     if [ ! -z $PYTHON ]; then
-        # Python binding generation is very memory intensive. 
-        # Forcing 1 core to ensure it completes without running out of memory/hanging.
-        echo "Proceeding with binding generation using 1 core to prevent hanging..."
-        make -j 1 update_bindings
+        # Check if the total memory is less than 6GB.
+        if [ `cat /proc/meminfo | head -1 | awk '{print $2}'` -lt 6291456 ]; then
+            echo "Python binding generation is very memory intensive. At least 6GB of RAM is recommended."
+            echo "Proceeding with binding generation using 1 core..."
+            make -j 1 update_bindings
+        else
+            make update_bindings
+        fi
     fi
     make
     ${SUDO} make install

--- a/scripts/RADI/install-ompl-ubuntu.sh
+++ b/scripts/RADI/install-ompl-ubuntu.sh
@@ -65,15 +65,6 @@ install_app_dependencies()
 
 install_ompl()
 {
-    # Attempt to install via pip first (New in OMPL 1.7.0)
-    if [ ! -z $PYTHON ] && [ -z $APP ] && [ -z $GITHUB ]; then
-        if ${SUDO} pip${PYTHONV} install ompl==1.7.0; then
-            echo "OMPL 1.7.0 installed via pip."
-            return 0
-        fi
-        echo "Pip install failed, falling back to source..."
-    fi
-
     if [ -z $APP ]; then
         OMPL="ompl"
     else
@@ -91,20 +82,16 @@ install_ompl()
         ${SUDO} apt-get -y install git
         git clone --recurse-submodules https://github.com/ompl/${OMPL}.git
         cd $OMPL
-        git checkout 1.7.0 # Updated to 1.7.0 tag
+        git checkout 0f990886e9e40014e32ddee177c8d798adbc8fb7 # Temporary: with this commit works
     fi
     mkdir -p build/Release
     cd build/Release
     cmake ../.. -DPYTHON_EXEC=/usr/bin/python${PYTHONV}
     if [ ! -z $PYTHON ]; then
-        # Check if the total memory is less than 6GB.
-        if [ `cat /proc/meminfo | head -1 | awk '{print $2}'` -lt 6291456 ]; then
-            echo "Python binding generation is very memory intensive. At least 6GB of RAM is recommended."
-            echo "Proceeding with binding generation using 1 core..."
-            make -j 1 update_bindings
-        else
-            make update_bindings
-        fi
+        # Python binding generation is very memory intensive. 
+        # Forcing 1 core to ensure it completes without running out of memory/hanging.
+        echo "Proceeding with binding generation using 1 core to prevent hanging..."
+        make -j 1 update_bindings
     fi
     make
     ${SUDO} make install

--- a/scripts/RADI/install-ompl-ubuntu.sh
+++ b/scripts/RADI/install-ompl-ubuntu.sh
@@ -65,24 +65,33 @@ install_app_dependencies()
 
 install_ompl()
 {
+    # Attempt to install via pip first (New in OMPL 1.7.0)
+    if [ ! -z $PYTHON ] && [ -z $APP ] && [ -z $GITHUB ]; then
+        if ${SUDO} pip${PYTHONV} install ompl==1.7.0; then
+            echo "OMPL 1.7.0 installed via pip."
+            return 0
+        fi
+        echo "Pip install failed, falling back to source..."
+    fi
+
     if [ -z $APP ]; then
         OMPL="ompl"
     else
         OMPL="omplapp"
     fi
     if [ -z $GITHUB ]; then
-        if [ -z $APP]; then
-            wget -O - https://github.com/ompl/${OMPL}/archive/1.6.0.tar.gz | tar zxf -
-            cd ${OMPL}-1.6.0
+        if [ -z $APP ]; then
+            wget -O - https://github.com/ompl/${OMPL}/archive/1.7.0.tar.gz | tar zxf -
+            cd ${OMPL}-1.7.0
         else
-            wget -O - https://github.com/ompl/${OMPL}/releases/download/1.6.0/${OMPL}-1.6.0-Source.tar.gz | tar zxf -
-            cd $OMPL-1.6.0-Source
+            wget -O - https://github.com/ompl/${OMPL}/releases/download/1.7.0/${OMPL}-1.7.0-Source.tar.gz | tar zxf -
+            cd $OMPL-1.7.0-Source
         fi
     else
         ${SUDO} apt-get -y install git
         git clone --recurse-submodules https://github.com/ompl/${OMPL}.git
         cd $OMPL
-        git checkout 0f990886e9e40014e32ddee177c8d798adbc8fb7 # Temporary: with this commit works
+        git checkout 1.7.0 # Updated to 1.7.0 tag
     fi
     mkdir -p build/Release
     cd build/Release


### PR DESCRIPTION
### Description
This PR updates the OMPL installation script install-ompl-ubuntu.sh to version **1.7.0**. It introduces a significant optimization by prioritizing `pip` wheels over source compilation. 

### Fixes
Closes #3040 

###Changes
* **Version Bump:** Updated all references and download URLs from `1.6.0` to `1.7.0`.
* **Pip Optimization:** Added logic to attempt pip install ompl==1.7.0 before falling back to source compilation. This leverages the new Python wheels introduced in OMPL 1.7.0.

### Testing
I have validated these changes on an **Ubuntu 22.04 (ARM64)** environment. The testing process confirmed that the script correctly detects the architecture, installs the wheel, and that the library is functionally stable.

<img width="528" height="84" alt="Screenshot 2026-01-25 at 11 15 57 AM" src="https://github.com/user-attachments/assets/6681fcc5-bf3e-41e9-b50c-c359274a662c" />

**2. Version Confirmation**
Verified the installed metadata using pip show. The version is correctly registered as 1.7.0.
<img width="529" height="148" alt="Screenshot 2026-01-25 at 11 19 32 AM" src="https://github.com/user-attachments/assets/605f1241-c096-40d9-a968-337232d0f0e2" />

**3. Functional Planning Test**
Ran a Python test script using og.SimpleSetup to verify the library's functionality. The planner successfully initialized, checked state validity, and found a path between start and goal .
<img width="528" height="209" alt="Screenshot 2026-01-25 at 11 23 14 AM" src="https://github.com/user-attachments/assets/6d3bed25-6423-4511-be21-d5b8432a56cf" />
