### PR TITLE
Add YouTube frame extractor tool for Computer Vision exercises

### DIFF
--- a/scripts/tools/README.md
+++ b/scripts/tools/README.md
@@ -1,0 +1,53 @@
+# YouTube Frame Extractor
+Extract frames from YouTube videos for Computer Vision exercises in RoboticsAcademy.
+
+## Purpose
+This tool allows students to:
+- Extract frames from YouTube videos containing robotics/computer vision content
+- Use real-world video data for testing CV algorithms
+- Avoid downloading entire videos (saves disk space)
+
+## Installation
+Install required dependencies:
+```bash
+pip install yt-dlp opencv-python
+
+## Usage
+Basic Usage
+python youtube_frame_extractor.py "https://www.youtube.com/watch?v=VIDEO_ID"
+
+## Advanced Options
+python youtube_frame_extractor.py "https://www.youtube.com/watch?v=VIDEO_ID" \
+    --output my_frames \
+    --interval 60 \
+    --max-frames 50
+
+## Parameters
+url (required): YouTube video URL
+--output or -o: Output folder name (default: frames)
+--interval or -i: Extract every Nth frame (default: 30)
+--max-frames or -m: Maximum frames to extract (default: 100)
+
+## Examples
+Extract 100 frames (every 30th frame):
+bash
+python youtube_frame_extractor.py "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+Extract 50 frames (every 60th frame) to custom folder:
+bash
+python youtube_frame_extractor.py "https://www.youtube.com/watch?v=dQw4w9WgXcQ" -o robot_frames -i 60 -m 50
+
+## Output
+Frames are saved as JPEG images:
+frame_0000.jpg
+frame_0001.jpg
+frame_0002.jpg
+...
+
+## Use Cases
+Testing color detection algorithms
+Training machine learning models
+Analyzing robot movement patterns
+Computer vision exercise datasets
+
+## Related Issue
+Addresses GitHub Issue #3058

--- a/scripts/tools/youtube_frame_extractor.py
+++ b/scripts/tools/youtube_frame_extractor.py
@@ -2,16 +2,22 @@
 """
 YouTube Frame Extractor Tool for RoboticsAcademy, Extracts frames from YouTube videos for Computer Vision exercises
 """
+
 import cv2
 import argparse
 import os
 import sys
+
 try:
     import yt_dlp
 except ImportError:
     print("ERROR: yt-dlp not installed. Install with: pip install yt-dlp")
     sys.exit(1)
-def extract_frames_from_youtube(url, output_folder="frames", frame_interval=30, max_frames=100):
+
+
+def extract_frames_from_youtube(
+    url, output_folder="frames", frame_interval=30, max_frames=100
+):
     """
     Extract frames from a YouTube video
     Args:
@@ -26,15 +32,12 @@ def extract_frames_from_youtube(url, output_folder="frames", frame_interval=30, 
     os.makedirs(output_folder, exist_ok=True)
     print(f"Fetching video from: {url}")
     # Get video stream URL using yt-dlp
-    ydl_opts = {
-        'format': 'best[ext=mp4]',
-        'quiet': True
-    }
+    ydl_opts = {"format": "best[ext=mp4]", "quiet": True}
     try:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=False)
-            video_url = info['url']
-            video_title = info.get('title', 'video')
+            video_url = info["url"]
+            video_title = info.get("title", "video")
         print(f"Video: {video_title}")
         print(f"Extracting frames (every {frame_interval} frames)...")
         # Open video with OpenCV
@@ -50,7 +53,9 @@ def extract_frames_from_youtube(url, output_folder="frames", frame_interval=30, 
                 break
             # Save every Nth frame
             if frame_count % frame_interval == 0:
-                frame_filename = os.path.join(output_folder, f"frame_{saved_count:04d}.jpg")
+                frame_filename = os.path.join(
+                    output_folder, f"frame_{saved_count:04d}.jpg"
+                )
                 cv2.imwrite(frame_filename, frame)
                 saved_count += 1
                 if saved_count % 10 == 0:
@@ -62,28 +67,46 @@ def extract_frames_from_youtube(url, output_folder="frames", frame_interval=30, 
     except Exception as e:
         print(f"ERROR: {e}")
         return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Extract frames from YouTube videos for Computer Vision exercises"
     )
-    parser.add_argument('url', help='YouTube video URL')
-    parser.add_argument('--output', '-o', default='frames', help='Output folder for frames (default: frames)')
-    parser.add_argument('--interval', '-i', type=int, default=30, help='Extract every Nth frame (default: 30)')
-    parser.add_argument('--max-frames', '-m', type=int, default=100, help='Maximum frames to extract (default: 100)')
+    parser.add_argument("url", help="YouTube video URL")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="frames",
+        help="Output folder for frames (default: frames)",
+    )
+    parser.add_argument(
+        "--interval",
+        "-i",
+        type=int,
+        default=30,
+        help="Extract every Nth frame (default: 30)",
+    )
+    parser.add_argument(
+        "--max-frames",
+        "-m",
+        type=int,
+        default=100,
+        help="Maximum frames to extract (default: 100)",
+    )
     args = parser.parse_args()
     print("=" * 60)
     print("RoboticsAcademy - YouTube Frame Extractor")
     print("=" * 60)
     frames_extracted = extract_frames_from_youtube(
-        args.url,
-        args.output,
-        args.interval,
-        args.max_frames
+        args.url, args.output, args.interval, args.max_frames
     )
     if frames_extracted > 0:
         print(f"\nFrames saved to: {os.path.abspath(args.output)}")
     else:
         print("\nFailed to extract frames")
         sys.exit(1)
+
+
 if __name__ == "__main__":
     main()

--- a/scripts/tools/youtube_frame_extractor.py
+++ b/scripts/tools/youtube_frame_extractor.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+YouTube Frame Extractor Tool for RoboticsAcademy, Extracts frames from YouTube videos for Computer Vision exercises
+"""
+import cv2
+import argparse
+import os
+import sys
+try:
+    import yt_dlp
+except ImportError:
+    print("ERROR: yt-dlp not installed. Install with: pip install yt-dlp")
+    sys.exit(1)
+def extract_frames_from_youtube(url, output_folder="frames", frame_interval=30, max_frames=100):
+    """
+    Extract frames from a YouTube video
+    Args:
+        url (str): YouTube video URL
+        output_folder (str): Folder to save extracted frames
+        frame_interval (int): Extract every Nth frame
+        max_frames (int): Maximum number of frames to extract
+    Returns:
+        int: Number of frames extracted
+    """
+    # Create output folder if it doesn't exist
+    os.makedirs(output_folder, exist_ok=True)
+    print(f"Fetching video from: {url}")
+    # Get video stream URL using yt-dlp
+    ydl_opts = {
+        'format': 'best[ext=mp4]',
+        'quiet': True
+    }
+    try:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+            video_url = info['url']
+            video_title = info.get('title', 'video')
+        print(f"Video: {video_title}")
+        print(f"Extracting frames (every {frame_interval} frames)...")
+        # Open video with OpenCV
+        cap = cv2.VideoCapture(video_url)
+        if not cap.isOpened():
+            print("ERROR: Could not open video stream")
+            return 0
+        frame_count = 0
+        saved_count = 0
+        while cap.isOpened() and saved_count < max_frames:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            # Save every Nth frame
+            if frame_count % frame_interval == 0:
+                frame_filename = os.path.join(output_folder, f"frame_{saved_count:04d}.jpg")
+                cv2.imwrite(frame_filename, frame)
+                saved_count += 1
+                if saved_count % 10 == 0:
+                    print(f"Extracted {saved_count} frames...")
+            frame_count += 1
+        cap.release()
+        print(f"\n✓ Successfully extracted {saved_count} frames to '{output_folder}/'")
+        return saved_count
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return 0
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract frames from YouTube videos for Computer Vision exercises"
+    )
+    parser.add_argument('url', help='YouTube video URL')
+    parser.add_argument('--output', '-o', default='frames', help='Output folder for frames (default: frames)')
+    parser.add_argument('--interval', '-i', type=int, default=30, help='Extract every Nth frame (default: 30)')
+    parser.add_argument('--max-frames', '-m', type=int, default=100, help='Maximum frames to extract (default: 100)')
+    args = parser.parse_args()
+    print("=" * 60)
+    print("RoboticsAcademy - YouTube Frame Extractor")
+    print("=" * 60)
+    frames_extracted = extract_frames_from_youtube(
+        args.url,
+        args.output,
+        args.interval,
+        args.max_frames
+    )
+    if frames_extracted > 0:
+        print(f"\nFrames saved to: {os.path.abspath(args.output)}")
+    else:
+        print("\nFailed to extract frames")
+        sys.exit(1)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi! This PR adds a tool to extract frames from YouTube videos.

I noticed issue #3058 mentioned needing this feature for CV exercises, so I implemented a simple Python script that: 
- Takes a YouTube URL and extracts frames from the video
- Lets you configure how many frames to extract and the interval between them
- Saves frames as JPG images in a folder
- Has a simple command-line interface

The tool uses yt-dlp to get the video stream and OpenCV to extract frames. I added a README with usage examples and installation instructions. This should be helpful for students who want to test their CV algorithms on real videos without downloading huge files.

**Dependencies needed:**
- yt-dlp
- opencv - python

Let me know if you'd like me to change anything or add more features!
Fixes #3058
