### PR TITLE
fix(frontend): enforce fresh application state on launch (reset theme/filters)

### DIFF
--- a/react_frontend/src/index.tsx
+++ b/react_frontend/src/index.tsx
@@ -6,6 +6,20 @@ import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import { Home, projectLoader, Studio } from "Routes";
 
+// Clear stored state on app startup to ensure fresh state on every launch
+// This removes theme preferences, search filters, and other cached UI state
+const clearStoredState = () => {
+  // Clear localStorage items (theme preferences)
+  window.localStorage.removeItem("themeType");
+
+  // Clear sessionStorage items (search/filter state)
+  window.sessionStorage.removeItem("ra_home_filters_v1");
+  window.sessionStorage.removeItem("ra_home_search_v1");
+};
+
+// Execute immediately before React mounts
+clearStoredState();
+
 const router = createBrowserRouter([
   {
     path: "/academy",


### PR DESCRIPTION
Fixes "Cookies and local storage..." (Issue #3108 - Part 2)

**Context**
This is a follow-up to PR #3416. While the previous backend fix resolved the file caching issues (stale JS bundles), the application was still retaining user state (Theme Preference, Search Filters) in `localStorage` across sessions. This prevented the "fresh start" behavior requested by maintainers (e.g., users would see "Light Mode" on launch instead of the default "Dark Mode").

**The Fix**
Implemented a `clearStoredState()` routine in the application entry point (`index.tsx`).
* **Mechanism:** This function executes synchronously before the React `root` is mounted.
* **Targeted Cleanup:** Explicitly removes `themeType`, `ra_home_filters_v1`, and `ra_home_search_v1`.
* **Result:** Ensures the `AcademyThemeContext` and `Search` components always initialize with default values (Dark Mode) on every launch, regardless of previous sessions.

**Verification**
* **Manual Test:** Manually injected `localStorage.setItem('themeType', 'light')` in the console to simulate a stale state.
* **Result:** Upon refreshing the page, `localStorage.getItem('themeType')` returned `null`, and the UI correctly rendered in Dark Mode immediately.

**Note on Cookies:**
I investigated the browser `Cookies` storage and confirmed it only contains essential Django session/CSRF tokens. I deliberately excluded them from the cleanup routine to prevent invalidating the user's active login session on every refresh. The persistence issue was isolated entirely to `localStorage`.