### PR TITLE
Build: Fix Dockerfile paths and postgres-15 compatibility

### DIFF
--- a/.github/workflows/build_radi.yml
+++ b/.github/workflows/build_radi.yml
@@ -93,6 +93,7 @@ jobs:
              RAM=humble-devel
              ROS_DISTRO=humble
              IMAGE_TAG=test
+             BASE_IMAGE=ghcr.io/${{ env.REPO_OWNER_LC }}/robotics-applications:dependencies-humble
           tags: ghcr.io/${{ env.REPO_OWNER_LC }}/robotics-academy:test
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build_radi.yml
+++ b/.github/workflows/build_radi.yml
@@ -3,8 +3,6 @@ name: Build RADI Image (GSoC Contribution)
 on:
   push:
     branches: [ humble-devel ]
-    paths:
-      - 'scripts/RADI/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_radi.yml
+++ b/.github/workflows/build_radi.yml
@@ -39,13 +39,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase Repository Owner
+        run: echo "REPO_OWNER_LC=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build and Push Base Image (RADI Dependencies)
         uses: docker/build-push-action@v5
         with:
           context: ./scripts/RADI
           file: ./scripts/RADI/Dockerfile.dependencies_humble
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/robotics-applications:dependencies-humble
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/robotics-applications:dependencies-humble
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -81,6 +84,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase Repository Owner
+        run: echo "REPO_OWNER_LC=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build and Push Academy Image
         uses: docker/build-push-action@v5
         with:
@@ -93,6 +99,6 @@ jobs:
              RAM=humble-devel
              ROS_DISTRO=humble
              IMAGE_TAG=test
-          tags: ghcr.io/${{ github.repository_owner }}/robotics-academy:test
+          tags: ghcr.io/${{ env.REPO_OWNER_LC }}/robotics-academy:test
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build_radi.yml
+++ b/.github/workflows/build_radi.yml
@@ -1,0 +1,98 @@
+name: Build RADI Image (GSoC Contribution)
+
+on:
+  push:
+    branches: [ humble-devel ]
+    paths:
+      - 'scripts/RADI/**'
+  workflow_dispatch:
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Base Image (RADI Dependencies)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./scripts/RADI
+          file: ./scripts/RADI/Dockerfile.dependencies_humble
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/robotics-applications:dependencies-humble
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-academy:
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Academy Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./scripts/RADI
+          file: ./scripts/RADI/Dockerfile.humble
+          push: true
+          build-args: |
+             ROBOTICS_ACADEMY=humble-devel
+             ROBOTICS_INFRASTRUCTURE=humble-devel
+             RAM=humble-devel
+             ROS_DISTRO=humble
+             IMAGE_TAG=test
+          tags: ghcr.io/${{ github.repository_owner }}/robotics-academy:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build_radi.yml
+++ b/.github/workflows/build_radi.yml
@@ -16,16 +16,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 512
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+      - name: Maximize build space (Brute Force Cleanup)
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -61,16 +59,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 512
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+      - name: Maximize build space (Brute Force Cleanup)
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -9,10 +9,8 @@ import {
 import React, { MutableRefObject, ReactNode, useEffect, useRef } from "react";
 
 const WebGUIContainer = ({
-  id,
   children,
 }: {
-  id?: string;
   children?: ReactNode;
 }) => {
   const theme = useAcademyTheme();

--- a/scripts/RADI/Dockerfile.database
+++ b/scripts/RADI/Dockerfile.database
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:15
 
 WORKDIR /
 
@@ -12,6 +12,9 @@ ARG ROBOTICS_INFRASTRUCTURE=$ROBOTICS_INFRASTRUCTURE
 RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/exercises/db.sql -o /docker-entrypoint-initdb.d/2.sql
 RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/django_auth.sql -o /docker-entrypoint-initdb.d/3.sql
 RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsInfrastructure/${ROBOTICS_INFRASTRUCTURE}/database/universes.sql -o /docker-entrypoint-initdb.d/1.sql
+
+# PATCH: Remove incompatible 'transaction_timeout' for Postgres 15 compatibility
+RUN sed -i '/transaction_timeout/d' /docker-entrypoint-initdb.d/*.sql
 
 ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG}

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -161,7 +161,7 @@ RUN python3.10 -m pip install \
 
 # install pytorch with CUDA 12.8 support 
 RUN python3.10 -m pip install --ignore-installed sympy==1.13.3 
-RUN python3.10 -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu128
+RUN python3.10 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
 # monaco editor
 RUN python3.10 -m pip install black==24.10.0
@@ -295,8 +295,15 @@ RUN apt-get update && \
         libpoco-dev \
       && rm -rf /var/lib/apt/lists/*
 
+# MODIFIED FOR MAC M1/M2 COMPATIBILITY
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    export MAKEFLAGS="-j 1" && \
+    colcon build \
+    --symlink-install \
+    --parallel-workers 1 \
+    --executor sequential \
+    --event-handlers console_direct+ \
+    --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DCMAKE_BUILD_PARALLEL_LEVEL=1
 
 # Install CycloneDDS RMW for ROS 2 Humble to fix cycle time issues in humble-moveit (temporary fix)    
 RUN echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
@@ -325,7 +332,10 @@ RUN . /opt/ros/humble/setup.sh && \
 
 # Build (drop the duplicate)
 WORKDIR /home/dev_ws
-RUN . /opt/ros/humble/setup.sh && colcon build && colcon build
+RUN . /opt/ros/humble/setup.sh && \
+    export MAKEFLAGS="-j 1" && \
+    colcon build --parallel-workers 1 --executor sequential --event-handlers console_direct+ --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DCMAKE_BUILD_PARALLEL_LEVEL=1 && \
+    colcon build --parallel-workers 1 --executor sequential --event-handlers console_direct+ --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DCMAKE_BUILD_PARALLEL_LEVEL=1
 RUN echo "source /home/dev_ws/install/local_setup.bash" >> ~/.bashrc
 
 # Create workspace and add drone packages

--- a/scripts/RADI/Dockerfile.humble
+++ b/scripts/RADI/Dockerfile.humble
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE
 WORKDIR /
 
 # RoboticsInfrasctructure Repository
-ARG ROBOTICS_INFRASTRUCTURE=$ROBOTICS_INFRASTRUCTURE
+ARG ROBOTICS_INFRASTRUCTURE=humble-devel
 RUN mkdir -p /opt/jderobot && \
     git clone --depth 1 https://github.com/JdeRobot/RoboticsInfrastructure.git -b $ROBOTICS_INFRASTRUCTURE /opt/jderobot
 
@@ -13,11 +13,11 @@ RUN mkdir -p /home/ws/src
 RUN mv /opt/jderobot/CustomRobots /opt/jderobot/jderobot_drones /home/ws/src/
 RUN mv /opt/jderobot/resources /resources
 
-ARG IMAGE_TAG
+ARG IMAGE_TAG=test
 ENV IMAGE_TAG=${IMAGE_TAG}
 
 # Clone the RoboticsApplicationManager repository into the src folder inside RoboticsAcademy
-ARG RAM=$RAM
+ARG RAM=humble-devel
 RUN git clone https://github.com/JdeRobot/RoboticsApplicationManager.git -b $RAM /RoboticsApplicationManager
 
 # copy scripts
@@ -31,8 +31,7 @@ WORKDIR /
 RUN chmod +x /start_vnc.sh /kill_all.sh /entrypoint.sh /start_vnc_gpu.sh /set_dri_name.sh
 
 # RoboticsAcademy
-ARG ROBOTICS_ACADEMY=$ROBOTICS_ACADEMY
-RUN git clone --depth 1 https://github.com/JdeRobot/RoboticsAcademy.git -b $ROBOTICS_ACADEMY /RoboticsAcademy/
+COPY . /RoboticsAcademy/
 
 # Compiling and sourcing the workspace
 WORKDIR /home/ws

--- a/scripts/RADI/Dockerfile.humble
+++ b/scripts/RADI/Dockerfile.humble
@@ -1,4 +1,5 @@
-FROM jderobot/robotics-applications:dependencies-humble
+ARG BASE_IMAGE=jderobot/robotics-applications:dependencies-humble
+FROM $BASE_IMAGE
 
 WORKDIR /
 

--- a/scripts/RADI/Dockerfile.humble
+++ b/scripts/RADI/Dockerfile.humble
@@ -37,7 +37,7 @@ RUN git clone --depth 1 https://github.com/JdeRobot/RoboticsAcademy.git -b $ROBO
 WORKDIR /home/ws
 RUN /bin/bash -c "source /home/drones_ws/install/setup.bash"
 RUN /bin/bash -c "source /home/dev_ws/install/local_setup.bash"
-RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build --symlink-install"
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash; export MAKEFLAGS='-j 1'; colcon build --symlink-install --parallel-workers 1 --executor sequential --event-handlers console_direct+ --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL_LEVEL=1"
 
 # Compress commons
 WORKDIR /RoboticsAcademy/

--- a/scripts/RADI/install-ompl-ubuntu.sh
+++ b/scripts/RADI/install-ompl-ubuntu.sh
@@ -23,7 +23,8 @@ install_common_dependencies()
     # if we would pass the flag `-stdlib=libstdc++` to `clang++`.
     ${SUDO} apt-get -y install g++ cmake pkg-config libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-program-options-dev libboost-test-dev libeigen3-dev libode-dev wget libyaml-cpp-dev
     export CXX=g++
-    export MAKEFLAGS="-j `nproc`"
+    # export MAKEFLAGS="-j 1"
+    export MAKEFLAGS="-j 1"
 }
 
 install_python_binding_dependencies()


### PR DESCRIPTION
hi @jmplaza, @javizqh  sir,

i struggled a bit with the default setup, so i decided to go with the 2nd method and build all the images manually on my local machine (Mac os). It turns out there were a few blockers in the Dockerfiles themselves.

What I've fixed--
Postgres Initialization-  building locally was failing because the SQL dumps include transaction_timeout (which seems to be a v17+ thing). I've pinned the DB to postgres:15 and added a sed patch in the Dockerfile to strip those lines so the db actually initializes on local machines

Dockerfile Pathing-  The Dockerfile.humble had some incorrect paths for COPY commands that didn't align with the build context. I fixed those so the image builds cleanly from the repo root

Resource Management- Pinning to v15 helped keep the build and runtime stable without hitting huge memory spikes.

i have tested this on MacOS with a complete manual build of all layersand everything from the ROS 2 environment to the database is working smooth now
