### PR TITLE
Updated the Docs by adding run methord for RADI

### DIFF
--- a/docs/generate_a_radi.md
+++ b/docs/generate_a_radi.md
@@ -40,7 +40,18 @@ The goal of creating a new non official RADI is to test new dockerfile dependenc
 
 `IMAGE_TAG`: This is the tag of the Docker image that will be created. Default value is `test`.
 
-3. **Change the tag when launching RA**: launch the tag of the robotics-academy docker image to the one you have just created. If you are using either the developer script or docker compose remember to change the tag in the corresponding **compose*cfg/dev_humble*\*.yaml** file.
+3. **Run the Docker image**
+
+   Navigate back to the root of the repository and run the startup script:
+
+   ```bash
+   cd ../..
+   ./scripts/run_academy.sh
+   ```
+
+   Access the interface at [http://0.0.0.0:7164/](http://0.0.0.0:7164/)
+
+4. **Change the tag when launching RA**: launch the tag of the robotics-academy docker image to the one you have just created. If you are using either the developer script or docker compose remember to change the tag in the corresponding **compose*cfg/dev_humble*\*.yaml** file.
 
 ## Example
 


### PR DESCRIPTION
The method to run the custom RADI was not mentioned clearly. I have added detailed instructions describing how to execute it using the run_academy.sh script.
This will make it easier for developers who want to run a custom RADI configuration, as they can now directly use the run_academy.sh script without confusion.

<img width="1132" height="310" alt="Screenshot 2026-02-20 at 1 48 18 AM" src="https://github.com/user-attachments/assets/ca775c60-2582-4ead-bec4-053d197be547" />
