### PR TITLE
Fixed build issue on macOs

### DIFF
--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -296,7 +296,8 @@ RUN apt-get update && \
       && rm -rf /var/lib/apt/lists/*
 
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    export MAKEFLAGS="-j1" && \
+    colcon build --parallel-workers 1 --executor sequential --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 # Install CycloneDDS RMW for ROS 2 Humble to fix cycle time issues in humble-moveit (temporary fix)    
 RUN echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
@@ -325,7 +326,7 @@ RUN . /opt/ros/humble/setup.sh && \
 
 # Build (drop the duplicate)
 WORKDIR /home/dev_ws
-RUN . /opt/ros/humble/setup.sh && colcon build && colcon build
+RUN . /opt/ros/humble/setup.sh && export MAKEFLAGS="-j1" && colcon build --parallel-workers 1 --executor sequential && colcon build --parallel-workers 1 --executor sequential
 RUN echo "source /home/dev_ws/install/local_setup.bash" >> ~/.bashrc
 
 # Create workspace and add drone packages

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -296,8 +296,11 @@ RUN apt-get update && \
       && rm -rf /var/lib/apt/lists/*
 
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    export MAKEFLAGS="-j1" && \
-    colcon build --parallel-workers 1 --executor sequential --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      export MAKEFLAGS="-j1" && colcon build --parallel-workers 1 --executor sequential --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release; \
+    else \
+      colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release; \
+    fi
 
 # Install CycloneDDS RMW for ROS 2 Humble to fix cycle time issues in humble-moveit (temporary fix)    
 RUN echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
@@ -326,7 +329,13 @@ RUN . /opt/ros/humble/setup.sh && \
 
 # Build (drop the duplicate)
 WORKDIR /home/dev_ws
-RUN . /opt/ros/humble/setup.sh && export MAKEFLAGS="-j1" && colcon build --parallel-workers 1 --executor sequential && colcon build --parallel-workers 1 --executor sequential
+ARG TARGETARCH
+RUN . /opt/ros/humble/setup.sh && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      export MAKEFLAGS="-j1" && colcon build --executor sequential --parallel-workers 1 && colcon build --executor sequential --parallel-workers 1; \
+    else \
+      colcon build && colcon build; \
+    fi
 RUN echo "source /home/dev_ws/install/local_setup.bash" >> ~/.bashrc
 
 # Create workspace and add drone packages


### PR DESCRIPTION
hi @jmplaza @javizqh, sir

This PR fixes a Docker build issue on macOS where the colcon build step was failing with a “write jobserver: Bad file descriptor” error while building the as2_core package. The problem was due to the default parallel build setup not working properly in the macOS Docker environment. To fix it, I forced single-threaded compilation by adding export MAKEFLAGS="-j1" before each colcon build command and updated the commands to use --executor sequential and --parallel-workers 1. These changes were made in scripts/RADI/Dockerfile.dependencies_humble, and now the Docker image builds successfully on macOS without affecting any other functionality.