### PR TITLE
Fix Power Tower Inspection documentation imports.

### DIFF
--- a/_pages/exercises/Drones/power_tower_inspection.md
+++ b/_pages/exercises/Drones/power_tower_inspection.md
@@ -31,8 +31,8 @@ The goal of this exercise is to implement the logic that allows a quadrotor to p
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 while True:


### PR DESCRIPTION
This PR fixes the documentation of the Power Tower Inspection exercise.

The code snippet in the "Where to insert the code?" section was inconsistent
with the current exercise template, which could confuse users when starting
the exercise.

Changes:
- Updated import instructions to match the current python_template.
- No functional code changes were made.