### PR TITLE
feat: allow building RADI from custom github forks

### DIFF
--- a/.github/workflows/generate_Robotics_Academy.yml
+++ b/.github/workflows/generate_Robotics_Academy.yml
@@ -34,6 +34,16 @@ on:
         required: true
         default: humble
         type: string
+      academy_owner:
+        description: 'GitHub owner for RoboticsAcademy'
+        required: false
+        default: JdeRobot
+        type: string
+      infra_owner:
+        description: 'GitHub owner for RoboticsInfrastructure'
+        required: false
+        default: JdeRobot
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -65,6 +75,16 @@ on:
         description: 'ROS Distro (humble)'
         required: true
         default: humble
+        type: string
+      academy_owner:
+        description: 'GitHub owner for RoboticsAcademy'
+        required: false
+        default: JdeRobot
+        type: string
+      infra_owner:
+        description: 'GitHub owner for RoboticsInfrastructure'
+        required: false
+        default: JdeRobot
         type: string
 
 jobs:
@@ -114,6 +134,8 @@ jobs:
               --build-arg RAM=${{ github.event.inputs.RAM }} \
               --build-arg ROS_DISTRO=${{ github.event.inputs.ROS }} \
               --build-arg IMAGE_TAG=${TAG} \
+              --build-arg ACADEMY_OWNER=${{ github.event.inputs.academy_owner }} \
+              --build-arg INFRA_OWNER=${{ github.event.inputs.infra_owner }} \
               -t jderobot/robotics-academy:${TAG} .
             docker push jderobot/robotics-academy:${TAG}
           else

--- a/.github/workflows/generate_Robotics_Academy_Database.yml
+++ b/.github/workflows/generate_Robotics_Academy_Database.yml
@@ -24,6 +24,16 @@ on:
         required: true
         default: database
         type: string
+      academy_owner:
+        description: 'GitHub owner for RoboticsAcademy'
+        required: false
+        default: JdeRobot
+        type: string
+      infra_owner:
+        description: 'GitHub owner for RoboticsInfrastructure'
+        required: false
+        default: JdeRobot
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -43,6 +53,14 @@ on:
         description: 'Branch of Robotics Infrastructure for Universes Database'
         required: true
         default: database
+      academy_owner:
+        description: 'GitHub owner for RoboticsAcademy'
+        required: false
+        default: JdeRobot
+      infra_owner:
+        description: 'GitHub owner for RoboticsInfrastructure'
+        required: false
+        default: JdeRobot
 
 jobs:
   push_to_registry:
@@ -79,6 +97,8 @@ jobs:
             --build-arg IMAGE_TAG=${TAG}\
             --build-arg ROBOTICS_ACADEMY=${{ github.event.inputs.RA }}\
             --build-arg ROBOTICS_INFRASTRUCTURE=${{ github.event.inputs.RI }} \
+            --build-arg ACADEMY_OWNER=${{ github.event.inputs.academy_owner }} \
+            --build-arg INFRA_OWNER=${{ github.event.inputs.infra_owner }} \
             -t jderobot/robotics-database:${TAG} .
           docker push jderobot/robotics-database:${TAG}
       - name: Upload as Latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Save the version tag
         run: echo "TAG=${TAG#v}" >> $GITHUB_ENV
       - run: echo ${TAG}
-      - name: Check out the repo # checking our the code at current commit that triggers the workflow
+      - name: Check out the repo
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch-webserver-id }}
@@ -38,6 +38,7 @@ jobs:
           sudo apt-get update
           cd scripts/RADI
           docker build -f Dockerfile.dependencies_humble -t jderobot/robotics-applications:dependencies-humble .
+
       - name: Build and push RADI
         run: |
           cd scripts/RADI
@@ -47,12 +48,16 @@ jobs:
             --build-arg RAM=humble-devel \
             --build-arg ROS_DISTRO=humble \
             --build-arg IMAGE_TAG=${TAG} \
+            --build-arg ACADEMY_OWNER=JdeRobot \
+            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-academy:${TAG} .
           docker push jderobot/robotics-academy:${TAG}
+
       - name: Upload as Latest
         run: |
             docker image tag jderobot/robotics-academy:${TAG} jderobot/robotics-academy:latest
             docker push jderobot/robotics-academy:latest
+
   generate-RA-database-docker-image:
     name: Generate Robotics Academy Database Image
     runs-on: ubuntu-latest
@@ -62,7 +67,7 @@ jobs:
       - name: Save the version tag
         run: echo "TAG=${TAG#v}" >> $GITHUB_ENV
       - run: echo ${TAG}
-      - name: Check out the repo # checking our the code at current commit that triggers the workflow
+      - name: Check out the repo
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch-webserver-id }}
@@ -87,8 +92,11 @@ jobs:
             --build-arg IMAGE_TAG=${TAG}\
             --build-arg ROBOTICS_ACADEMY=humble-devel\
             --build-arg ROBOTICS_INFRASTRUCTURE=database \
+            --build-arg ACADEMY_OWNER=JdeRobot \
+            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-database:${TAG} .
           docker push jderobot/robotics-database:${TAG}
+
       - name: Upload as Latest
         run: |
             docker image tag jderobot/robotics-database:${TAG} jderobot/robotics-database:latest

--- a/.github/workflows/release_Robotics_Academy.yml
+++ b/.github/workflows/release_Robotics_Academy.yml
@@ -33,6 +33,14 @@ on:
         description: 'ROS Distro (humble)'
         required: true
         default: humble
+      academy_owner:
+        description: 'GitHub owner for RoboticsAcademy'
+        required: false
+        default: JdeRobot
+      infra_owner:
+        description: 'GitHub owner for RoboticsInfrastructure'
+        required: false
+        default: JdeRobot
 
 jobs:
   generate-RA-docker-image:
@@ -45,7 +53,10 @@ jobs:
       RI: ${{ github.event.inputs.RI }}
       RAM: ${{ github.event.inputs.RAM }}
       ROS: ${{ github.event.inputs.ROS }}
+      academy_owner: ${{ github.event.inputs.academy_owner }}
+      infra_owner: ${{ github.event.inputs.infra_owner }}
     secrets: inherit
+
   generate-RA-database-docker-image:
     name: Generate Robotics Academy Database Image
     uses: ./.github/workflows/generate_Robotics_Academy_Database.yml
@@ -54,4 +65,6 @@ jobs:
       latest: ${{ inputs.latest }}
       RA: ${{ github.event.inputs.RA }}
       RI: ${{ github.event.inputs.RIDB }}
+      academy_owner: ${{ github.event.inputs.academy_owner }}
+      infra_owner: ${{ github.event.inputs.infra_owner }}
     secrets: inherit

--- a/scripts/RADI/Dockerfile.database
+++ b/scripts/RADI/Dockerfile.database
@@ -7,11 +7,13 @@ RUN apt-get update && apt-get install -y curl
 
 ARG ROBOTICS_ACADEMY=$ROBOTICS_ACADEMY
 ARG ROBOTICS_INFRASTRUCTURE=$ROBOTICS_INFRASTRUCTURE
+ARG ACADEMY_OWNER=JdeRobot
+ARG INFRA_OWNER=JdeRobot
 
 # Download databases
-RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/exercises/db.sql -o /docker-entrypoint-initdb.d/2.sql
-RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/django_auth.sql -o /docker-entrypoint-initdb.d/3.sql
-RUN curl -sL https://raw.githubusercontent.com/JdeRobot/RoboticsInfrastructure/${ROBOTICS_INFRASTRUCTURE}/database/universes.sql -o /docker-entrypoint-initdb.d/1.sql
+RUN curl -sL https://raw.githubusercontent.com/${ACADEMY_OWNER}/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/exercises/db.sql -o /docker-entrypoint-initdb.d/2.sql
+RUN curl -sL https://raw.githubusercontent.com/${ACADEMY_OWNER}/RoboticsAcademy/${ROBOTICS_ACADEMY}/database/django_auth.sql -o /docker-entrypoint-initdb.d/3.sql
+RUN curl -sL https://raw.githubusercontent.com/${INFRA_OWNER}/RoboticsInfrastructure/${ROBOTICS_INFRASTRUCTURE}/database/universes.sql -o /docker-entrypoint-initdb.d/1.sql
 
 ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG}

--- a/scripts/RADI/Dockerfile.humble
+++ b/scripts/RADI/Dockerfile.humble
@@ -4,8 +4,9 @@ WORKDIR /
 
 # RoboticsInfrasctructure Repository
 ARG ROBOTICS_INFRASTRUCTURE=$ROBOTICS_INFRASTRUCTURE
+ARG INFRA_OWNER=JdeRobot
 RUN mkdir -p /opt/jderobot && \
-    git clone --depth 1 https://github.com/JdeRobot/RoboticsInfrastructure.git -b $ROBOTICS_INFRASTRUCTURE /opt/jderobot
+    git clone --depth 1 https://github.com/${INFRA_OWNER}/RoboticsInfrastructure.git -b $ROBOTICS_INFRASTRUCTURE /opt/jderobot
 
 # create workspace and add Robot packages
 RUN mkdir -p /home/ws/src
@@ -30,7 +31,8 @@ RUN chmod +x /start_vnc.sh /kill_all.sh /entrypoint.sh /start_vnc_gpu.sh /set_dr
 
 # RoboticsAcademy
 ARG ROBOTICS_ACADEMY=$ROBOTICS_ACADEMY
-RUN git clone --depth 1 https://github.com/JdeRobot/RoboticsAcademy.git -b $ROBOTICS_ACADEMY /RoboticsAcademy/
+ARG ACADEMY_OWNER=JdeRobot
+RUN git clone --depth 1 https://github.com/${ACADEMY_OWNER}/RoboticsAcademy.git -b $ROBOTICS_ACADEMY /RoboticsAcademy/
 
 # Compiling and sourcing the workspace
 WORKDIR /home/ws

--- a/scripts/RADI/build.sh
+++ b/scripts/RADI/build.sh
@@ -9,25 +9,31 @@ IMAGE_TAG="test"
 FORCE_BUILD=false
 FORCE_BUILD_NO_CACHE=false
 
+# Default GitHub owners
+ACADEMY_OWNER="JdeRobot"
+INFRA_OWNER="JdeRobot"
+RAM_OWNER="JdeRobot"
+
 Help()
 {
    # Display Help
    echo "Syntax: build.sh [options]"
    echo "Options:"
-   echo "  -h                        Print this Help."
-   echo "  -f                        Force creation of the base image. If omitted, the base image is created only if "
-   echo "                            it doesn't exist."
-   echo "  -F                        Force creation of the base image without using docker cache."
-   echo "  -a, --academy    <value>  Branch of RoboticsAcademy.               Default: humble-devel"
-   echo "  -i, --infra      <value>  Branch of RoboticsInfrastructure.        Default: humble-devel"
-   echo "  -m, --ram        <value>  Branch of RoboticsApplicationManager.    Default: humble-devel"
-   echo "  -r, --ros        <value>  ROS Distro (humble).                     Default: humble"
-   echo "  -t, --tag        <value>  Tag name of the image.                   Default: test"
+   echo "  -h                           Print this Help."
+   echo "  -f                           Force creation of the base image. If omitted, the base image is created only if it doesn't exist."
+   echo "  -F                           Force creation of the base image without using docker cache."
+   echo "  -a, --academy       <value>  Branch of RoboticsAcademy.               Default: humble-devel"
+   echo "  -i, --infra         <value>  Branch of RoboticsInfrastructure.        Default: humble-devel"
+   echo "  -m, --ram           <value>  Branch of RoboticsApplicationManager.    Default: humble-devel"
+   echo "  -r, --ros           <value>  ROS Distro (humble).                     Default: humble"
+   echo "  -t, --tag           <value>  Tag name of the image.                   Default: test"
+   echo "  --academy-owner     <value>  GitHub owner for RoboticsAcademy.        Default: JdeRobot"
+   echo "  --infra-owner       <value>  GitHub owner for RoboticsInfrastructure. Default: JdeRobot"
+   echo "  --ram-owner         <value>  GitHub owner for RAM.                    Default: JdeRobot"
    echo
    echo "Example:"
    echo "   ./build.sh -t my_image"
-   echo "   ./build.sh -f -a master -i humble-devel -m main -r humble -t my_image" 
-   echo "   ./build.sh -f --academy master --infra humble-devel --ram main --ros humble --tag my_image" 
+   echo "   ./build.sh --academy-owner aquintan4 -a issue-3476 -t my_image" 
    echo
 }
 
@@ -53,6 +59,18 @@ while [[ $# -gt 0 ]]; do
             IMAGE_TAG="$2"
             shift 2
             ;;
+        --academy-owner)
+            ACADEMY_OWNER="$2"
+            shift 2
+            ;;
+        --infra-owner)
+            INFRA_OWNER="$2"
+            shift 2
+            ;;
+        --ram-owner)
+            RAM_OWNER="$2"
+            shift 2
+            ;;
         -f | --force)
             FORCE_BUILD=true
             shift
@@ -75,9 +93,9 @@ while [[ $# -gt 0 ]]; do
    esac
 done
 
-echo "ROBOTICS_ACADEMY:-------------:$ROBOTICS_ACADEMY"
-echo "ROBOTICS_INFRASTRUCTURE:------:$ROBOTICS_INFRASTRUCTURE"
-echo "RAM:--------------------------:$RAM"
+echo "ROBOTICS_ACADEMY:-------------:$ROBOTICS_ACADEMY (Owner: $ACADEMY_OWNER)"
+echo "ROBOTICS_INFRASTRUCTURE:------:$ROBOTICS_INFRASTRUCTURE (Owner: $INFRA_OWNER)"
+echo "RAM:--------------------------:$RAM (Owner: $RAM_OWNER)"
 echo "ROS_DISTRO:-------------------:$ROS_DISTRO"
 echo "IMAGE_TAG:--------------------:$IMAGE_TAG"
 echo
@@ -121,4 +139,7 @@ docker build --no-cache -f $DOCKERFILE \
   --build-arg RAM=$RAM \
   --build-arg ROS_DISTRO=$ROS_DISTRO \
   --build-arg IMAGE_TAG=$IMAGE_TAG \
+  --build-arg ACADEMY_OWNER=$ACADEMY_OWNER \
+  --build-arg INFRA_OWNER=$INFRA_OWNER \
+  --build-arg RAM_OWNER=$RAM_OWNER \
   -t jderobot/robotics-academy:$IMAGE_TAG .

--- a/scripts/RADI/build.sh
+++ b/scripts/RADI/build.sh
@@ -12,11 +12,9 @@ FORCE_BUILD_NO_CACHE=false
 # Default GitHub owners
 ACADEMY_OWNER="JdeRobot"
 INFRA_OWNER="JdeRobot"
-RAM_OWNER="JdeRobot"
 
 Help()
 {
-   # Display Help
    echo "Syntax: build.sh [options]"
    echo "Options:"
    echo "  -h                           Print this Help."
@@ -29,17 +27,16 @@ Help()
    echo "  -t, --tag           <value>  Tag name of the image.                   Default: test"
    echo "  --academy-owner     <value>  GitHub owner for RoboticsAcademy.        Default: JdeRobot"
    echo "  --infra-owner       <value>  GitHub owner for RoboticsInfrastructure. Default: JdeRobot"
-   echo "  --ram-owner         <value>  GitHub owner for RAM.                    Default: JdeRobot"
    echo
    echo "Example:"
    echo "   ./build.sh -t my_image"
-   echo "   ./build.sh --academy-owner aquintan4 -a issue-3476 -t my_image" 
+   echo "   ./build.sh --academy-owner aquintan4 -a issue-3476 -t my_image"
    echo
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -a | --academy) 
+        -a | --academy)
             ROBOTICS_ACADEMY="$2"
             shift 2
             ;;
@@ -67,10 +64,6 @@ while [[ $# -gt 0 ]]; do
             INFRA_OWNER="$2"
             shift 2
             ;;
-        --ram-owner)
-            RAM_OWNER="$2"
-            shift 2
-            ;;
         -f | --force)
             FORCE_BUILD=true
             shift
@@ -79,7 +72,7 @@ while [[ $# -gt 0 ]]; do
             FORCE_BUILD_NO_CACHE=true
             shift
             ;;
-        -h | --help) # display Help
+        -h | --help)
             echo "Generates RoboticsAcademy RoboticsBackend image"
             echo
             Help
@@ -95,12 +88,11 @@ done
 
 echo "ROBOTICS_ACADEMY:-------------:$ROBOTICS_ACADEMY (Owner: $ACADEMY_OWNER)"
 echo "ROBOTICS_INFRASTRUCTURE:------:$ROBOTICS_INFRASTRUCTURE (Owner: $INFRA_OWNER)"
-echo "RAM:--------------------------:$RAM (Owner: $RAM_OWNER)"
+echo "RAM:--------------------------:$RAM"
 echo "ROS_DISTRO:-------------------:$ROS_DISTRO"
 echo "IMAGE_TAG:--------------------:$IMAGE_TAG"
 echo
 
-# Determine Dockerfile based on ROS_DISTRO
 if [[ $ROS_DISTRO == "humble" ]]; then
     DOCKERFILE_BASE="Dockerfile.dependencies_humble"
     DOCKERFILE="Dockerfile.humble"
@@ -115,7 +107,6 @@ else
   NO_CACHE=""
 fi
 
-# Build the Docker Base image
 if $FORCE_BUILD_NO_CACHE || $FORCE_BUILD || [[ "$(docker images -q jderobot/robotics-applications:dependencies-$ROS_DISTRO 2> /dev/null)" == "" ]]; then
   echo "===================== BUILDING $ROS_DISTRO BASE IMAGE ====================="
   echo "Building base using $DOCKERFILE_BASE for ROS $ROS_DISTRO"
@@ -129,7 +120,6 @@ else
     exit
 fi
 
-# Build the Docker image
 echo "===================== BUILDING $ROS_DISTRO RoboticsBackend ====================="
 echo "Building RoboticsBackend using $DOCKERFILE for ROS $ROS_DISTRO"
 
@@ -141,5 +131,4 @@ docker build --no-cache -f $DOCKERFILE \
   --build-arg IMAGE_TAG=$IMAGE_TAG \
   --build-arg ACADEMY_OWNER=$ACADEMY_OWNER \
   --build-arg INFRA_OWNER=$INFRA_OWNER \
-  --build-arg RAM_OWNER=$RAM_OWNER \
   -t jderobot/robotics-academy:$IMAGE_TAG .


### PR DESCRIPTION
Allows building the RADI from personal forks without manual Dockerfile edits

- Added --academy-owner, --infra-owner, and --ram-owner flags to build.sh.
- Replaced hardcoded JdeRobot URLs with ARG variables in Dockerfile.humble and Dockerfile.database.
- Kept JdeRobot as the default

<img width="1084" height="417" alt="image" src="https://github.com/user-attachments/assets/82a8b6fb-cbe6-49fa-b204-19140c114b89" />
