### PR TITLE
Fix: Ensure webcam stream stops on component unmount #3498

### DIFF
--- a/react_frontend/src/components/visualizers/Camera.tsx
+++ b/react_frontend/src/components/visualizers/Camera.tsx
@@ -75,14 +75,13 @@ const Camera = ({ visible }: { visible: boolean }) => {
     setManager(exerciseContext.manager);
   }, [exerciseContext]);
 
-  useEffect(() => {
+ useEffect(() => {
     if (isVisualReady) {
       startWebcam();
     }
+    // Cleanup function
     return () => {
-      if (isVisualReady) {
-        stopWebcam();
-      }
+      stopWebcam(); 
     };
   }, [isVisualReady]);
 
@@ -90,7 +89,7 @@ const Camera = ({ visible }: { visible: boolean }) => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: {
-          facingMode: "user", // Request the front camera (selfie camera)
+          facingMode: "user", // Request the front cam                  era (selfie camera)
         },
       });
       if (videoRef.current) {


### PR DESCRIPTION
Overview
This PR addresses issue #3498, where the webcam remains active (LED stays on) even after exiting an exercise.

Changes

Modified the useEffect hook in Camera.tsx to include a proper cleanup function.

The stopWebcam() function is now called unconditionally when the component unmounts.

This ensures all media tracks are stopped, releasing the hardware resource properly regardless of the isVisualReady state.
<img width="656" height="303" alt="image" src="https://github.com/user-attachments/assets/a9c6e3f0-2d5c-42c8-a476-0a88fe8579b7" />


Testing

Verified that stopWebcam() is triggered when navigating away from the exercise.

Confirmed that mediaStream.getTracks().forEach(track => track.stop()) is executed.

Fixes: #3498