### PR TITLE
Docs: update HAL and GUI imports

### DIFF
--- a/_pages/exercises/ComputerVision/image_processing.md
+++ b/_pages/exercises/ComputerVision/image_processing.md
@@ -30,8 +30,8 @@ This exercise is an introduction to the image processing world. In this practice
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
-* `from GUI import GUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
+* `import WebGUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 * `HAL.getImage(frame)` - to get the frame corresponding to the i position
 * `GUI.showImage()` - allows you to view a debug image or with relevant information
 

--- a/_pages/exercises/ComputerVision/opticalflow_teleop.md
+++ b/_pages/exercises/ComputerVision/opticalflow_teleop.md
@@ -45,8 +45,8 @@ In this practice the intention is to develop an optical flow algorithm to teleop
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
-* `from GUI import GUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
+* `import WebGUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 * `HAL.getImage()` - to get the image
 * `GUI.showImage()` - allows you to view a debug image or with relevant information
 * `HAL.motors.sendV()` - to set the linear speed

--- a/_pages/exercises/Drones/drone_cat_mouse.md
+++ b/_pages/exercises/Drones/drone_cat_mouse.md
@@ -31,8 +31,8 @@ In this exercise, the cat quadrotor has to be programmed by the student to follo
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/drone_gymkhana.md
+++ b/_pages/exercises/Drones/drone_gymkhana.md
@@ -37,8 +37,8 @@ The goal of this exercise is to learn how to control a drone to complete a gymkh
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/drone_hangar.md
+++ b/_pages/exercises/Drones/drone_hangar.md
@@ -29,8 +29,8 @@ The goal of this exercise is to implement the logic that allows a quadrotor to e
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/drone_tello.md
+++ b/_pages/exercises/Drones/drone_tello.md
@@ -28,8 +28,8 @@ The goal of this exercise is to implement the logic to make the tello drone be a
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/follow_turtlebot.md
+++ b/_pages/exercises/Drones/follow_turtlebot.md
@@ -28,8 +28,8 @@ The goal of this exercise is to implement the logic that allows a quadrotor to f
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/labyrinth_escape.md
+++ b/_pages/exercises/Drones/labyrinth_escape.md
@@ -29,8 +29,8 @@ The goal of this exercise is to implement the logic that allows a quadrotor to e
 
 Some explanations about the above code:
 - It has two parts, a sequential one and iterative one. The sequential (before the while loop) just execs once, while the iterative execs forever.
-- `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-- `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+- `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+- `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 You can access to the drone methods through the Hardware Abstraction Layer (HAL).
 

--- a/_pages/exercises/Drones/package_delivery.md
+++ b/_pages/exercises/Drones/package_delivery.md
@@ -30,8 +30,8 @@ The goal of this exercise is to implement the logic that allows a quadrotor to d
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/position_control.md
+++ b/_pages/exercises/Drones/position_control.md
@@ -89,8 +89,8 @@ more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 while True:
@@ -109,8 +109,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/power_tower_inspection.md
+++ b/_pages/exercises/Drones/power_tower_inspection.md
@@ -51,8 +51,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/Drones/visual_lander.md
+++ b/_pages/exercises/Drones/visual_lander.md
@@ -70,8 +70,8 @@ more $HOME/.roboticsacademy/log/2021-11-06-14-45/manager.log
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 while True:
@@ -90,8 +90,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 
 ### Sensors and drone state
 

--- a/_pages/exercises/IndustrialRobots/machine_vision.md
+++ b/_pages/exercises/IndustrialRobots/machine_vision.md
@@ -75,7 +75,7 @@ The goal of this exercise is to learn how to **use vision to assist an industria
 In the launched webpage, type your code in the text editor:
 
 ```python
-from HAL import HAL
+import HAL
 # Enter sequential code!
 
 while True:

--- a/_pages/exercises/IndustrialRobots/mobile_manipulation.md
+++ b/_pages/exercises/IndustrialRobots/mobile_manipulation.md
@@ -91,8 +91,8 @@ The mobile manipulator is MMO-500 robot from [Neobotix](https://www.neobotix-rob
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 
@@ -112,8 +112,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware(Gazebo).
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 * `HAL.back_to_home()` - Command the robot arm and gripper to move back to the home pose.
 * `HAL.pickup()` - to set the linear speed
 * `HAL.place()` - to set the angular velocity

--- a/_pages/exercises/IndustrialRobots/pick_place.md
+++ b/_pages/exercises/IndustrialRobots/pick_place.md
@@ -116,7 +116,7 @@ increment_20 = [-0.4, -0.1, 0.4]
 In the launched webpage, type your code in the text editor and run it pressing the run button:
 
 ```python
-from HAL import HAL
+import HAL
 # Enter sequential code here!
 
 while True:

--- a/_pages/exercises/MobileRobots/localization_laser.md
+++ b/_pages/exercises/MobileRobots/localization_laser.md
@@ -81,8 +81,8 @@ docker run --rm -it -p 7164:7164 -p 2303:2303 -p 1905:1905 -p 8765:8765 -p 6080:
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 
@@ -102,8 +102,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
-* `from GUI import GUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL library class. This class contains the functions that receives information from the webcam.
+* `import WebGUI` - to import the GUI (Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 * `HAL.getPose3d().x` - to get position x of the robot 
 * `HAL.getPose3d().y` - to get position y of the robot 
 * `HAL.getPose3d().yaw` - to get the orientation of the robot 

--- a/_pages/exercises/MobileRobots/real_follow_person.md
+++ b/_pages/exercises/MobileRobots/real_follow_person.md
@@ -120,8 +120,8 @@ To use the real *TurtleBot2* we have to follow this steps:
 In the launched webpage, type your code in the text editor,
 
 ```python
-from GUI import GUI
-from HAL import HAL
+import WebGUI
+import HAL
 # Enter sequential code!
 
 
@@ -141,8 +141,8 @@ while True:
 
 ## Robot API
 
-* `from HAL import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware.
-* `from GUI import GUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
+* `import HAL` - to import the HAL(Hardware Abstraction Layer) library class. This class contains the functions that sends and receives information to and from the Hardware.
+* `import WebGUI` - to import the GUI(Graphical User Interface) library class. This class contains the functions used to view the debugging information, like image widgets.
 * `HAL.getImage()` - to obtain the current frame of the camera robot.
 * `HAL.getPose3d().x` - to get the position of the robot (x coordinate)
 * `HAL.getPose3d().y` - to obtain the position of the robot (y coordinate)


### PR DESCRIPTION
This PR updates the documentation across multiple exercises to reflect the current RoboticsAcademy latest imports.

### Changes
- Replaced `from GUI import GUI` with `import WebGUI`
- Replaced `from HAL import HAL` with `import HAL`