### PR TITLE
Fix - Prevent Follow Line map rendering before connection

### DIFF
--- a/exercises/follow_line/frontend/WebGUI.tsx
+++ b/exercises/follow_line/frontend/WebGUI.tsx
@@ -20,7 +20,7 @@ const WebGUI = () => {
   const [image, setImage] = useState<string | undefined>(undefined);
   const [lapTime, setLapTime] = useState<string | undefined>(undefined);
   const [carPose, setCarPose] = useState<number[] | undefined>(undefined);
-  const [circuitImg, setCircuitImg] = useState(defaultCircuit);
+  const [circuitImg, setCircuitImg] = useState<string | undefined>(undefined);
   const [manager, setManager] = useState(exerciseContext.manager);
 
   useEffect(() => {
@@ -100,7 +100,7 @@ const WebGUI = () => {
           {lapTime} s
         </label>
       )}
-      {image && (
+      {circuitImg && (
         <div className="overlay" id="circuit-aerial">
           <img src={circuitImg} alt="" id="circuit-img" />
           {carPose && (

--- a/exercises/follow_line/frontend/WebGUI.tsx
+++ b/exercises/follow_line/frontend/WebGUI.tsx
@@ -100,15 +100,17 @@ const WebGUI = () => {
           {lapTime} s
         </label>
       )}
-      <div className="overlay" id="circuit-aerial">
-        <img src={circuitImg} alt="" id="circuit-img" />
-        {carPose && (
-          <div
-            id="circuit-car-pos"
-            style={{ top: carPose[1], left: carPose[0] }}
-          />
-        )}
-      </div>
+      {image && (
+        <div className="overlay" id="circuit-aerial">
+          <img src={circuitImg} alt="" id="circuit-img" />
+          {carPose && (
+            <div
+              id="circuit-car-pos"
+              style={{ top: carPose[1], left: carPose[0] }}
+            />
+          )}
+        </div>
+      )}
     </WebGUIContainer>
   );
 };


### PR DESCRIPTION
## Bug Description :

In the Follow Line exercise, the circuit map was rendered 
immediately when the page loaded, even before the exercise was connected.

## Fix :

The circuit overlay is now conditionally rendered only when the 
connection is done. Since the image is received only after 
connection and RUNNING state, this ensures the map is displayed 
at the correct time.

## Files Modified :

- exercises/follow_line/frontend/WebGUI.tsx