### PR TITLE
fix(build.sh): pass TARGETARCH build argument for stable Mac ARM builds

### DIFF
--- a/.github/workflows/generate_Robotics_Academy.yml
+++ b/.github/workflows/generate_Robotics_Academy.yml
@@ -114,8 +114,6 @@ jobs:
               --build-arg RAM=${{ github.event.inputs.RAM }} \
               --build-arg ROS_DISTRO=${{ github.event.inputs.ROS }} \
               --build-arg IMAGE_TAG=${TAG} \
-              --build-arg ACADEMY_OWNER=${{ github.event.inputs.academy_owner }} \
-              --build-arg INFRA_OWNER=${{ github.event.inputs.infra_owner }} \
               -t jderobot/robotics-academy:${TAG} .
             docker push jderobot/robotics-academy:${TAG}
           else

--- a/.github/workflows/generate_Robotics_Academy.yml
+++ b/.github/workflows/generate_Robotics_Academy.yml
@@ -100,7 +100,7 @@ jobs:
           sudo apt-get update
           cd scripts/RADI
           if [ "${{ github.event.inputs.ROS }}" == "humble" ]; then
-            docker build -f Dockerfile.dependencies_humble -t jderobot/robotics-applications:dependencies-humble .
+            docker build --build-arg TARGETARCH=amd64 -f Dockerfile.dependencies_humble -t jderobot/robotics-applications:dependencies-humble .
           else
             echo "Incorrect ROS version"
           fi

--- a/.github/workflows/generate_Robotics_Academy.yml
+++ b/.github/workflows/generate_Robotics_Academy.yml
@@ -114,6 +114,8 @@ jobs:
               --build-arg RAM=${{ github.event.inputs.RAM }} \
               --build-arg ROS_DISTRO=${{ github.event.inputs.ROS }} \
               --build-arg IMAGE_TAG=${TAG} \
+              --build-arg ACADEMY_OWNER=${{ github.event.inputs.academy_owner }} \
+              --build-arg INFRA_OWNER=${{ github.event.inputs.infra_owner }} \
               -t jderobot/robotics-academy:${TAG} .
             docker push jderobot/robotics-academy:${TAG}
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Save the version tag
         run: echo "TAG=${TAG#v}" >> $GITHUB_ENV
       - run: echo ${TAG}
-      - name: Check out the repo # checking our the code at current commit that triggers the workflow
+      - name: Check out the repo
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch-webserver-id }}
@@ -37,7 +37,8 @@ jobs:
         run: |
           sudo apt-get update
           cd scripts/RADI
-          docker build -f Dockerfile.dependencies_humble -t jderobot/robotics-applications:dependencies-humble .
+          docker build --build-arg TARGETARCH=amd64 -f Dockerfile.dependencies_humble -t jderobot/robotics-applications:dependencies-humble .
+
       - name: Build and push RADI
         run: |
           cd scripts/RADI
@@ -47,12 +48,16 @@ jobs:
             --build-arg RAM=humble-devel \
             --build-arg ROS_DISTRO=humble \
             --build-arg IMAGE_TAG=${TAG} \
+            --build-arg ACADEMY_OWNER=JdeRobot \
+            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-academy:${TAG} .
           docker push jderobot/robotics-academy:${TAG}
+
       - name: Upload as Latest
         run: |
             docker image tag jderobot/robotics-academy:${TAG} jderobot/robotics-academy:latest
             docker push jderobot/robotics-academy:latest
+
   generate-RA-database-docker-image:
     name: Generate Robotics Academy Database Image
     runs-on: ubuntu-latest
@@ -62,7 +67,7 @@ jobs:
       - name: Save the version tag
         run: echo "TAG=${TAG#v}" >> $GITHUB_ENV
       - run: echo ${TAG}
-      - name: Check out the repo # checking our the code at current commit that triggers the workflow
+      - name: Check out the repo
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch-webserver-id }}
@@ -87,8 +92,11 @@ jobs:
             --build-arg IMAGE_TAG=${TAG}\
             --build-arg ROBOTICS_ACADEMY=humble-devel\
             --build-arg ROBOTICS_INFRASTRUCTURE=database \
+            --build-arg ACADEMY_OWNER=JdeRobot \
+            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-database:${TAG} .
           docker push jderobot/robotics-database:${TAG}
+
       - name: Upload as Latest
         run: |
             docker image tag jderobot/robotics-database:${TAG} jderobot/robotics-database:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
             --build-arg RAM=humble-devel \
             --build-arg ROS_DISTRO=humble \
             --build-arg IMAGE_TAG=${TAG} \
-            --build-arg ACADEMY_OWNER=JdeRobot \
-            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-academy:${TAG} .
           docker push jderobot/robotics-academy:${TAG}
 
@@ -92,8 +90,6 @@ jobs:
             --build-arg IMAGE_TAG=${TAG}\
             --build-arg ROBOTICS_ACADEMY=humble-devel\
             --build-arg ROBOTICS_INFRASTRUCTURE=database \
-            --build-arg ACADEMY_OWNER=JdeRobot \
-            --build-arg INFRA_OWNER=JdeRobot \
             -t jderobot/robotics-database:${TAG} .
           docker push jderobot/robotics-database:${TAG}
 

--- a/scripts/RADI/build.sh
+++ b/scripts/RADI/build.sh
@@ -101,7 +101,9 @@ fi
 if $FORCE_BUILD_NO_CACHE || $FORCE_BUILD || [[ "$(docker images -q jderobot/robotics-applications:dependencies-$ROS_DISTRO 2> /dev/null)" == "" ]]; then
   echo "===================== BUILDING $ROS_DISTRO BASE IMAGE ====================="
   echo "Building base using $DOCKERFILE_BASE for ROS $ROS_DISTRO"
-  docker build $NO_CACHE -f $DOCKERFILE_BASE -t jderobot/robotics-applications:dependencies-$ROS_DISTRO .
+  docker build $NO_CACHE -f $DOCKERFILE_BASE \
+    --build-arg TARGETARCH=$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/') \
+    -t jderobot/robotics-applications:dependencies-$ROS_DISTRO .
 fi
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
hi @javizqh @jmplaza sir,

On apple silicon (mac m1/m2/m3), the base image nvidia/opengl used in this project is amd64-only, this causes docker desktop to run the build process under amd64 emulation (via rosetta 2/QEMU).

inside the emulated container, TARGETARCH is incorrectly detected as amd64, which triggers the default parallel build logic in the dockerfile, which are highly unstable and frequently crash due to memory exhaustion or GNU make jobserver failures

This PR modifies scrips/RADI/build.sh to explicitly detect the host architecture and pass it as a build argument.