### PR TITLE
autoparking: stabilize 3d lidar webgui rendering and reduce desync

### DIFF
--- a/common/hal_interfaces/hal_interfaces/general/lidar.py
+++ b/common/hal_interfaces/hal_interfaces/general/lidar.py
@@ -33,25 +33,23 @@ def pointCloud2LidarData(cloud):
     if not cloud or cloud.width * cloud.height == 0:
         return lidar
 
-    # Read XYZ points
+    # Read XYZ points - skip_nans=True is much faster as it filters in C++
     lidar.points = list(
-        point_cloud2.read_points(cloud, field_names=("x", "y", "z"), skip_nans=False)
+        point_cloud2.read_points(cloud, field_names=("x", "y", "z"), skip_nans=True)
     )
 
     # Read intensities if available
     if "intensity" in [f.name for f in cloud.fields]:
         intensities = point_cloud2.read_points(
-            cloud, field_names=("intensity",), skip_nans=False
+            cloud, field_names=("intensity",), skip_nans=True
         )
         lidar.intensities = [i[0] for i in intensities]
 
     # Timestamp (ROS 2 Time -> seconds)
     lidar.timeStamp = cloud.header.stamp.sec + (cloud.header.stamp.nanosec * 1e-9)
 
-    # Validate point cloud
-    lidar.is_dense = all(
-        all(np.isfinite(coord) for coord in point) for point in lidar.points
-    )
+    # dense means no NaNs/Infs. Since we skipped NaNs, it's dense.
+    lidar.is_dense = True
 
     return lidar
 
@@ -61,6 +59,8 @@ class LidarNode(Node):
         super().__init__("lidar_node")
         self._lock = Lock()
         self.last_cloud_ = None
+        self._cached_lidar = None
+        self._cached_stamp = None
         self.sub = self.create_subscription(
             sensor_msgs.msg.PointCloud2, topic, self.pointcloud_callback, 10
         )
@@ -71,7 +71,21 @@ class LidarNode(Node):
 
     def getLidarData(self):
         with self._lock:
-            return pointCloud2LidarData(self.last_cloud_)
+            cloud = self.last_cloud_
+            if cloud is None:
+                return LidarData()
+
+            stamp = (cloud.header.stamp.sec, cloud.header.stamp.nanosec)
+            if self._cached_lidar is not None and self._cached_stamp == stamp:
+                return self._cached_lidar
+
+        lidar_data = pointCloud2LidarData(cloud)
+
+        with self._lock:
+            self._cached_stamp = stamp
+            self._cached_lidar = lidar_data
+
+        return lidar_data
 
     def get_point_cloud(self):
         with self._lock:

--- a/exercises/autoparking/frontend/WebGUI.tsx
+++ b/exercises/autoparking/frontend/WebGUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { states } from "jderobot-commsmanager";
 import { useExercise } from "Contexts/ExerciseContext";
 import WebGUI3D from "Components/exercise/WebGUI3D";
@@ -11,6 +11,7 @@ const WebGUI = () => {
   const [manager, setManager] = useState(exerciseContext.manager);
   const [reset, setReset] = useState(false);
   const [pointsToPaint, setPointsToPaint] = useState<number[][] | undefined>();
+  const lidarFramesRef = useRef<number[][][]>([]);
 
   useEffect(() => {
     setManager(exerciseContext.manager);
@@ -20,21 +21,30 @@ const WebGUI = () => {
     let data = updateData as any;
     data = data.update;
 
-    if (data.lidar) {
-      const point = JSON.parse(data.lidar);
-      var pdata: number[][] = [];
-      if (point != "") {
-        for (
-          let index = 0;
-          index < point.length;
-          index += Math.round(point.length / 2500)
-        ) {
-          pdata.push(point[index]);
+    if (typeof data.lidar === "string") {
+      try {
+        const points = JSON.parse(data.lidar) as number[][];
+        if (Array.isArray(points) && points.length > 0) {
+          lidarFramesRef.current.push(points);
+          if (lidarFramesRef.current.length > 3) {
+            lidarFramesRef.current.shift();
+          }
+          const mergedPoints = lidarFramesRef.current.reduce<number[][]>(
+            (acc, frame) => acc.concat(frame),
+            []
+          );
+          setPointsToPaint(mergedPoints);
+        } else {
+          // If LiDAR frame is empty, clear buffered frames to avoid stale ghosts.
+          lidarFramesRef.current = [];
+          setPointsToPaint([]);
         }
-        setPointsToPaint(pdata);
+      } catch {
+        // Ignore malformed websocket frames and keep last valid render.
       }
     }
     if (data.map) {
+      lidarFramesRef.current = [];
       const map_data = JSON.parse(data.map);
       var pdata: number[][] = [];
 

--- a/exercises/autoparking/python_template/WebGUI.py
+++ b/exercises/autoparking/python_template/WebGUI.py
@@ -1,4 +1,5 @@
 import json
+import math
 import subprocess
 
 from gui_interfaces.general.measuring_threading_gui_harmonic import (
@@ -16,7 +17,7 @@ class WebGUI(MeasuringThreadingGUI):
         super().__init__(host)
 
         # Payload vars
-        self.payload = {"map": ""}
+        self.payload = {"map": "", "lidar": ""}
         self.map = Map(getFrontLaserData, getRightLaserData, getBackLaserData)
 
         self.mode = "Laser"
@@ -30,30 +31,54 @@ class WebGUI(MeasuringThreadingGUI):
 
         self.start()
 
+    def _downsample_lidar_points(self, lidar_points):
+        voxel_size = 0.15
+        max_points = 5000
+        max_dist_sq = 2500.0
+        color = (20, 20, 255)
+
+        voxels = {}
+        for x, y, z in lidar_points:
+            if not (math.isfinite(x) and math.isfinite(y) and math.isfinite(z)):
+                continue
+
+            dist_sq = x * x + y * y + z * z
+            if dist_sq >= max_dist_sq:
+                continue
+
+            key = (
+                math.floor(x / voxel_size),
+                math.floor(y / voxel_size),
+                math.floor(z / voxel_size),
+            )
+            if key in voxels:
+                continue
+
+            voxels[key] = (x, y, z)
+            if len(voxels) >= max_points:
+                break
+
+        points = []
+        for key in sorted(voxels):
+            x, y, z = voxels[key]
+            points.append((float(x * 10), float((z + 1.75) * 10), float(-y * 10)) + color)
+
+        return points
+
     # Prepares and sends a map to the websocket server
     def update_gui(self):
 
         if self.mode == "Laser":
             map_message = self.map.get_json_data()
             self.payload["map"] = map_message
+            self.payload["lidar"] = ""
         elif self.mode == "Lidar":
             lidar = getLidarData()
             points = []
-            color = (20, 20, 255)
             if lidar:
-                for i in range(len(lidar.points)):
-                    is_valid = True
-                    for j in range(3):
-                        dist = lidar.points[i][j]
-                        if dist == float("inf") or dist == float("-inf"):
-                            is_valid = False
-                    if is_valid:
-                        x, y, z = lidar.points[i]
-                        points.append(
-                            (float(x * 10), float((z + 1.75) * 10), float(-y * 10))
-                            + color
-                        )
+                points = self._downsample_lidar_points(lidar.points)
             self.payload["lidar"] = json.dumps(points)
+            self.payload["map"] = ""
 
         message = json.dumps(self.payload)
         self.send_to_client(message)


### PR DESCRIPTION
## PR Description

fixes #3468


### Problem
During beta testing of the new **Autoparking universe (3D LiDAR)**, the WebGUI point cloud showed:

- Visible delay/desync vs Gazebo during motion (especially turns)
- Point flicker (points appearing/disappearing frame-to-frame)
- Occasional stale/ghost points staying on screen

#### Root causes identified
- Unstable frame sampling in backend visualization path
- Expensive repeated `PointCloud2 -> list` conversion even when the cloud didn’t change
- Frontend rendering behavior that could keep stale data on empty/malformed LiDAR updates
- Invalid float filtering logic in LiDAR preprocessing path

---

### What I changed

#### 1. Backend LiDAR visualization stabilization  
**File:** `exercises/autoparking/python_template/WebGUI.py`

- Replaced frame-index downsampling with **voxel-based spatial downsampling** (stable across frames)
- Added robust finite-number filtering using `math.isfinite`
- Limited rendered points (~5000) for performance/latency balance
- Ensured payload consistency by explicitly clearing inactive mode keys:
  - Laser mode sets `lidar=""`
  - Lidar mode sets `map=""`

---

#### 2. HAL LiDAR conversion performance  
**File:** `common/hal_interfaces/hal_interfaces/general/lidar.py`

- Switched to `read_points(..., skip_nans=True)` for faster native filtering and cleaner data
- Added timestamp-based cache in `LidarNode.getLidarData()`

If message stamp is unchanged:
```python
return cached_converted_lidar_data