### PR TITLE
Add Apple Silicon Mac support with -m flag

### DIFF
--- a/compose_cfg/dev_humble_cpu_mac.yaml
+++ b/compose_cfg/dev_humble_cpu_mac.yaml
@@ -1,0 +1,51 @@
+services:
+  my-postgres:
+    image: jderobot/robotics-database:latest
+    platform: linux/amd64
+    container_name: universe_db
+    networks:
+      - db_network
+    environment:
+      POSTGRES_DB: academy_db
+      POSTGRES_USER: user-dev
+      POSTGRES_PASSWORD: robotics-academy-dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./RoboticsInfrastructure/database/universes.sql:/docker-entrypoint-initdb.d/1.sql
+      - ./database/exercises/db.sql:/docker-entrypoint-initdb.d/2.sql
+      - ./database/django_auth.sql:/docker-entrypoint-initdb.d/3.sql
+    healthcheck:
+      test: pg_isready -U user-dev -d academy_db
+      interval: 3s
+      timeout: 1s
+      retries: 20
+
+  robotics-academy:
+    image: jderobot/robotics-academy:latest
+    platform: linux/amd64
+    container_name: developer-container
+    networks:
+      - db_network
+    command: "-s"
+    shm_size: '512mb'
+    ports:
+      - "7164:7164"
+      - "7163:7163"
+      - "6080-6090:6080-6090"
+    volumes:
+      - type: bind
+        source: ./
+        target: /RoboticsAcademy
+      - type: bind
+        source: ./src
+        target: /RoboticsApplicationManager
+      - ./RoboticsInfrastructure/database/universes.sql:/universes.sql
+    tty: true
+    stdin_open: true
+    depends_on:
+      my-postgres:
+        condition: service_healthy
+
+networks:
+  db_network:

--- a/compose_cfg/user_humble_cpu_mac.yaml
+++ b/compose_cfg/user_humble_cpu_mac.yaml
@@ -1,0 +1,32 @@
+services:
+  my-postgres:
+    image: jderobot/robotics-database:latest
+    platform: linux/amd64
+    container_name: universe_db
+    environment:
+      POSTGRES_DB: academy_db
+      POSTGRES_USER: user-dev
+      POSTGRES_PASSWORD: robotics-academy-dev
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: pg_isready -U user-dev -d academy_db
+      interval: 3s
+      timeout: 1s
+      retries: 20
+
+  robotics-academy:
+    image: jderobot/robotics-academy:latest
+    platform: linux/amd64
+    container_name: developer-container
+    command:  "-s"
+    shm_size: '512mb'
+    ports:
+      - "7164:7164"
+      - "7163:7163"
+      - "6080-6090:6080-6090"
+    tty: true
+    stdin_open: true
+    depends_on:
+      my-postgres:
+        condition: service_healthy

--- a/scripts/develop_academy.sh
+++ b/scripts/develop_academy.sh
@@ -6,6 +6,7 @@ branch="humble-devel"
 radi_version="humble"
 gpu_mode="false"
 nvidia="false"
+mac="false"
 compose_file="dev_humble_cpu"
 
 # Function to display help message
@@ -16,6 +17,7 @@ show_help() {
   echo "  -i  Specify the ROS2 version (default: humble)"
   echo "  -g  Enable GPU mode (default: false)"
   echo "  -n  Enable Nvidia support (default: false)"
+  echo "  -m  Enable Apple Silicon Mac mode with Rosetta x86_64 emulation (default: false)"
   echo "  -h  Display this help message"
 }
 
@@ -53,6 +55,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -n)
             nvidia="true"
+            shift 1
+            ;;
+        -m)
+            mac="true"
             shift 1
             ;;
         -h | --help) # display Help
@@ -185,6 +191,9 @@ if [ "$gpu_mode" = "true" ]; then
 fi
 if [ "$nvidia" = "true" ]; then
   compose_file="dev_humble_nvidia"
+fi
+if [ "$mac" = "true" ]; then
+  compose_file="dev_humble_cpu_mac"
 fi
 cp compose_cfg/$compose_file.yaml docker-compose.yaml
 

--- a/scripts/run_academy.sh
+++ b/scripts/run_academy.sh
@@ -3,6 +3,7 @@
 # Default: cpu and offline
 gpu_mode="false"
 nvidia="false"
+mac="false"
 base_path_offline="compose_cfg/"
 compose_file="user_humble_cpu"
 base_path_online="https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/humble-devel/compose_cfg/"
@@ -21,10 +22,11 @@ cleanup() {
 }
 
 # Loop through the arguments using a while loop
-while getopts ":g:n  " opt; do
+while getopts ":gnm" opt; do
   case $opt in
-    g) gpu_mode="true" ;; 
+    g) gpu_mode="true" ;;
     n) nvidia="true" ;;
+    m) mac="true" ;;
     \?) echo "Invalid option: -$OPTARG" >&2 ;;   # If an invalid option is provided, print an error message
   esac
 done
@@ -38,6 +40,9 @@ if [ "$gpu_mode" = "true" ]; then
 fi
 if [ "$nvidia" = "true" ]; then
   compose_file="user_humble_nvidia"
+fi
+if [ "$mac" = "true" ]; then
+  compose_file="user_humble_cpu_mac"
 fi
 
 # Check the mode


### PR DESCRIPTION
## Problem

On **Apple Silicon Macs (M1/M2/M3)**, running **RoboticsAcademy** with **Rosetta x86_64 emulation** causes the UI to hang indefinitely at:

> **"Connecting with robotics backend"**

This occurs because:

* Docker images are **amd64-only**, but the platform is not explicitly specified.
* **Gazebo** requires more shared memory than the default Docker allocation when running under **Rosetta emulation**.

---

## Solution

Added a **`-m` (Mac mode)** flag to the launch scripts and introduced new Docker Compose configurations with the necessary fixes.

---

## Changes

* `compose_cfg/user_humble_cpu_mac.yaml`
  New compose file with:

  * `platform: linux/amd64`
  * `shm_size: 512mb`

* `compose_cfg/dev_humble_cpu_mac.yaml`
  Same configuration added for **developer mode**.

* `scripts/run_academy.sh`
  Added a **`-m` flag** that selects the Mac-specific compose configuration.

* `scripts/develop_academy.sh`
  Added the **`-m` flag** along with updated help text.

---

## Usage

```bash
./scripts/run_academy.sh -m       # User mode on Apple Silicon Mac
./scripts/develop_academy.sh -m   # Developer mode on Apple Silicon Mac
```

---

## Demo Video

[https://github.com/user-attachments/assets/3824fe5b-078f-4f40-acfa-af0fe64875e4](https://github.com/user-attachments/assets/3824fe5b-078f-4f40-acfa-af0fe64875e4)

---
