### PR TITLE
Fix ESLint unused variable in WebGUIContainer.tsx

### DIFF
--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -19,7 +19,7 @@ const WebGUIContainer = ({
 
   return (
     <Box
-      id="webgui-container"
+      id={id}
       sx={{
         display: "flex",
         justifyContent: "center",

--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -9,7 +9,7 @@ import {
 import React, { MutableRefObject, ReactNode, useEffect, useRef } from "react";
 
 const WebGUIContainer = ({
-  id,
+  id = "webgui-container",
   children,
 }: {
   id?: string;


### PR DESCRIPTION
The Frontend Lint Workflow fails due to an unused id variable in WebGUIContainer.tsx.
This PR replaces the hardcoded id in the Box component with the id prop, resolving the @typescript-eslint/no-unused-vars lint error and restoring lint compliance.