### PR TITLE
Improve troubleshooting documentation for Docker container issues

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,27 +121,12 @@ docker compose -f dev_humble_cpu.yaml up
 docker compose -f dev_humble_cpu.yaml down
 docker compose -f dev_humble_cpu.yaml up
 ```
+
 ## Docker containers exit with status 255
 
-Sometimes the containers `developer-container` and `universe_db` may stop with **status 255**.
+Sometimes the containers `developer-container` and `universe_db` may stop with status 255.
 
-### Restart the environment
-
-Start the containers again using the same command style used in the Developer Guide:
+To restart the environment run:
 
 ```bash
-docker compose -f compose_cfg/dev_humble_cpu.yaml up
-```
-
-Check whether the containers are running:
-
-```bash
-docker ps
-```
-
-If the containers are still not running, restart them completely:
-
-```bash
-docker compose -f compose_cfg/dev_humble_cpu.yaml down
-docker compose -f compose_cfg/dev_humble_cpu.yaml up
-```
+docker-compose up

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,6 +41,74 @@ After this follow the steps provided in [official installation instructions](htt
 Sometimes the containers `developer-container` and `universe_db` may stop with status 255.
 
 To restart the environment:
+### [Back to main README.](../README.md)
+
+# Troubleshooting Robotics Academy
+
+## Docker does not launch
+
+If the Robotics Academy Docker container does not launch properly and shows an error saying it could not connect to the database, **only restart the Robotics Academy container**, not the database container that was launched separately via `docker compose`.
+
+---
+
+## PostgreSQL Port Conflict When Starting Database Container
+
+### Issue
+
+When following the [official installation instructions](https://jderobot.github.io/RoboticsAcademy/user_guide/#installation) to set up the Robotics Academy environment using Docker, you might encounter an error when launching the PostgreSQL container:
+
+```bash
+Error starting userland proxy: listen tcp4 0.0.0.0:5432: bind: address already in use
+```
+
+This usually occurs because port **5432** is already in use, commonly by a locally installed PostgreSQL service.
+
+### Example Scenario
+
+Suppose you successfully start the PostgreSQL Docker container once. Later, after stopping the container and rebooting your machine, your system's local PostgreSQL service might start automatically and occupy port **5432**. If you then try to restart the container, Docker will fail to bind to the port.
+
+---
+
+## Solution – Disable Local PostgreSQL Temporarily
+
+### Step 1: Stop and Disable Local PostgreSQL
+
+Run the following commands before launching the PostgreSQL container:
+
+```bash
+sudo systemctl stop postgresql
+sudo systemctl disable postgresql
+```
+
+After this, follow the steps provided in the
+[official installation instructions](https://jderobot.github.io/RoboticsAcademy/user_guide/#installation).
+
+---
+
+## Docker containers exit with status 255
+
+Sometimes the containers `developer-container` and `universe_db` may stop with **status 255**.
+
+### Restart the environment
+
+Start the containers again:
+
+```bash
+docker compose -f compose_cfg/dev_humble_cpu.yaml up
+```
+
+Check whether the containers are running:
+
+```bash
+docker ps
+```
+
+If the containers are still not running, restart them completely:
+
+```bash
+docker compose -f compose_cfg/dev_humble_cpu.yaml down
+docker compose -f compose_cfg/dev_humble_cpu.yaml up
+```
 
 ```bash
 cd compose_cfg
@@ -52,4 +120,28 @@ docker compose -f dev_humble_cpu.yaml up
 
 docker compose -f dev_humble_cpu.yaml down
 docker compose -f dev_humble_cpu.yaml up
+```
+## Docker containers exit with status 255
+
+Sometimes the containers `developer-container` and `universe_db` may stop with **status 255**.
+
+### Restart the environment
+
+Start the containers again using the same command style used in the Developer Guide:
+
+```bash
+docker compose -f compose_cfg/dev_humble_cpu.yaml up
+```
+
+Check whether the containers are running:
+
+```bash
+docker ps
+```
+
+If the containers are still not running, restart them completely:
+
+```bash
+docker compose -f compose_cfg/dev_humble_cpu.yaml down
+docker compose -f compose_cfg/dev_humble_cpu.yaml up
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,3 +35,21 @@ sudo systemctl disable postgresql
 ```
 
 After this follow the steps provided in [official installation instructions](https://jderobot.github.io/RoboticsAcademy/user_guide/#installation).
+
+## Docker containers exit with status 255
+
+Sometimes the containers `developer-container` and `universe_db` may stop with status 255.
+
+To restart the environment:
+
+```bash
+cd compose_cfg
+docker compose -f dev_humble_cpu.yaml up
+```
+``` docker ps
+```
+```If containers are not running: and they are showing
+
+docker compose -f dev_humble_cpu.yaml down
+docker compose -f dev_humble_cpu.yaml up
+```

--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -1,4 +1,8 @@
-import { Box } from "@mui/system";
+const WebGUIContainer = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => {import { Box } from "@mui/system";
 import { useAcademyTheme } from "Contexts/AcademyThemeContext";
 import {
   CommsManager,


### PR DESCRIPTION
## Summary
This PR improves the troubleshooting documentation by adding steps to resolve Docker container exit issues.

## Changes
- Added instructions for restarting containers using docker compose
- Added commands to verify running containers
- Added troubleshooting guidance for developer-container and universe_db failures

## Reason
While setting up RoboticsAcademy locally, the containers sometimes exited with status 255.
The added documentation helps new contributors diagnose and resolve this problem.

## Tested
Tested on Ubuntu with Docker Compose while running RoboticsAcademy locally.