### PR TITLE
Fix lint error: remove unused id prop from WebGUIContainer

### DIFF
--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -9,10 +9,8 @@ import {
 import React, { MutableRefObject, ReactNode, useEffect, useRef } from "react";
 
 const WebGUIContainer = ({
-  id,
   children,
 }: {
-  id?: string;
   children?: ReactNode;
 }) => {
   const theme = useAcademyTheme();


### PR DESCRIPTION
This PR removes the unused `id` prop from WebGUIContainer to fix the ESLint warning (`id` is defined but never used).