### PR TITLE
Add clarification comment for ROS2 initialization in HAL

### DIFF
--- a/exercises/follow_line/python_template/HAL.py
+++ b/exercises/follow_line/python_template/HAL.py
@@ -32,7 +32,7 @@ def __auto_spin() -> None:
         time.sleep(1 / freq)
 
 
-# ROS2 init
+# Initialize ROS2 node if it has not already been initialized
 if not rclpy.ok():
     rclpy.init(args=sys.argv)
 


### PR DESCRIPTION
This PR adds a clarifying comment explaining the ROS2 initialization condition in HAL.py.