### PR TITLE
Avoid accessing private 'ws' property of CommsManager

### DIFF
--- a/react_frontend/src/components/exercise/WebGUIContainer.tsx
+++ b/react_frontend/src/components/exercise/WebGUIContainer.tsx
@@ -90,11 +90,7 @@ export const connectApplication = (
     }
 
     end();
-
-    if (manager.ws.readyState !== WebSocket.OPEN) {
-      return;
-    }
-
+   
     const timer = window.setInterval(async () => {
       const state = manager.getState();
       if (


### PR DESCRIPTION
Fix: remove direct access to private `ws` property of CommsManager.

The code previously checked `manager.ws.readyState`, but `ws` is a private
property of `CommsManager` and should not be accessed outside the class.

The check is also redundant because:
1. `start()` is only triggered when the manager state is `TOOLS_READY` or `RUNNING`,
   meaning the connection is already established.
2. `manager.send()` is wrapped in a try/catch block which handles failures
   gracefully if the connection is not open.

This change removes the private field access and relies on the existing
connection handling in the public API.