### PR TITLE
remove production source maps

### DIFF
--- a/react_frontend/webpack.config.js
+++ b/react_frontend/webpack.config.js
@@ -106,5 +106,5 @@ module.exports = {
       filename: "css/[name].css",
     }),
   ],
-  devtool: "inline-source-map",
+  devtool: process.argv.includes("production") ? false : "inline-source-map",
 };


### PR DESCRIPTION
conditionally disables source-maps for production builds in webpack.config.js to reduce bundle size from ~20MB to ~1.5MB.

Fixes #3583
