### PR TITLE
fix(follow_line): make WebGUI console init resilient in headless runs

### DIFF
--- a/exercises/follow_line/python_template/WebGUI.py
+++ b/exercises/follow_line/python_template/WebGUI.py
@@ -157,7 +157,11 @@ class WebGUI(MeasuringThreadingGUI):
 # Create GUI instance directly
 host = "ws://127.0.0.1:2303"
 gui = WebGUI(host)
-start_console()
+try:
+    start_console()
+except Exception:
+    # Headless sessions can expose only /dev/pts/ptmx.
+    pass
 
 
 def showImage(image):


### PR DESCRIPTION
What this PR does

  This PR applies a minimal fix to `follow_line`:

  - `exercises/follow_line/python_template/WebGUI.py`
  - Wrap `start_console()` with a safe `try/except` during initialization.

 Why

  In headless sessions, console PTY initialization may fail and raise an exception during WebGUI startup.
  That exception can stop the exercise startup path.

  This change keeps startup alive when console init is unavailable, while preserving existing behavior when console init
  works.

 Scope

  - Focused only on `follow_line`
  - Single-file change
  - No local scripts, no Docker/local reliability tooling, no custom startup method

  Reproduction (official Robotics Academy flow)

  1. Open Robotics Academy using the official supported workflow.
  2. Enter `follow_line`.
  3. Click `Run`.
  4. In sessions where console PTY init fails, startup should continue instead of crashing.

