### PR TITLE
ros2-direct support for obstacle avoidance

### DIFF
--- a/exercises/obstacle_avoidance/python_template/WebGUI.py
+++ b/exercises/obstacle_avoidance/python_template/WebGUI.py
@@ -1,81 +1,162 @@
 import json
+import threading
+import sys
+import rclpy
+from rclpy.node import Node
+from rclpy.executors import MultiThreadedExecutor
+from geometry_msgs.msg import Point
+from std_msgs.msg import Bool
+from rclpy.qos import QoSProfile, DurabilityPolicy
 
+from hal_interfaces.general.odometry import OdometryNode
+from hal_interfaces.general.laser import LaserNode
 from gui_interfaces.general.measuring_threading_gui import MeasuringThreadingGUI
 from console_interfaces.general.console import start_console
 from lap import Lap
 from map import Map
-from HAL import getLaserData, getPose3d
 
-# Graphical User Interface Class
+class ROS2BridgeNode(Node):
+    def __init__(self, gui_instance):
+        super().__init__("gui_bridge_node")
+        self.gui = gui_instance
+        
+        self.create_subscription(Point, "/webgui/force/car", self.force_car_callback, 10)
+        self.create_subscription(Point, "/webgui/force/obs", self.force_obs_callback, 10)
+        self.create_subscription(Point, "/webgui/force/avg", self.force_avg_callback, 10)
+        self.create_subscription(Point, "/webgui/local_target", self.target_callback, 10)
+        self.create_subscription(Bool, "/webgui/target_reached", self.target_reached_callback, 10)
+        
+        qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.current_target_pub = self.create_publisher(Point, "/webgui/current_target", qos)
+        
+        self.current_target_obj = self.gui.map.getNextTarget()
+        self.publish_current_target()
 
+    def force_car_callback(self, msg):
+        self.gui.map.setCar(msg.x, msg.y)
+        
+    def force_obs_callback(self, msg):
+        self.gui.map.setObs(msg.x, msg.y)
+        
+    def force_avg_callback(self, msg):
+        self.gui.map.setAvg(msg.x, msg.y)
+        
+    def target_callback(self, msg):
+        self.gui.map.setTargetPos(msg.x, msg.y)
+
+    def target_reached_callback(self, msg):
+        if msg.data and self.current_target_obj:
+            self.current_target_obj.setReached(True)
+            self.current_target_obj = self.gui.map.getNextTarget()
+            self.publish_current_target()
+
+    def publish_current_target(self):
+        if self.current_target_obj:
+            msg = Point(
+                x=float(self.current_target_obj.getPose().x),
+                y=float(self.current_target_obj.getPose().y),
+                z=0.0
+            )
+            self.current_target_pub.publish(msg)
 
 class WebGUI(MeasuringThreadingGUI):
     def __init__(self, host="ws://127.0.0.1:2303"):
         super().__init__(host)
-
-        # Payload vars
+        
         self.payload = {"lap": "", "map": ""}
-        self.map = Map(getLaserData, getPose3d)
-        self.lap = Lap(self.map)
-
+        
+        self.pose3d_node = None
+        self.laser_node = None
+        self.bridge_node = None
+        self.executor = None
+        self.executor_thread = None
+        
+        self._setup_ros2()
         self.start()
 
-    # Prepares and sends a map to the websocket server
-    def update_gui(self):
+    def _setup_ros2(self):
+        if not rclpy.ok():
+            rclpy.init()
+            
+        self.pose3d_node = OdometryNode("/odom")
+        self.laser_node = LaserNode("/f1/laser/scan")
+        
+        self.map = Map(self.get_laser_data, self.get_pose3d)
+        self.lap = Lap(self.map)
+        
+        self.bridge_node = ROS2BridgeNode(self)
+        
+        self.executor = MultiThreadedExecutor()
+        self.executor.add_node(self.pose3d_node)
+        self.executor.add_node(self.laser_node)
+        self.executor.add_node(self.bridge_node)
+        
+        self.executor_thread = threading.Thread(
+            target=self.executor.spin,
+            daemon=True,
+            name="webgui_ros2_executor"
+        )
+        self.executor_thread.start()
 
+    def get_laser_data(self):
+        if self.laser_node is None:
+            return None
+        laser_data = self.laser_node.getLaserData()
+        while laser_data is not None and len(laser_data.values) == 0:
+            laser_data = self.laser_node.getLaserData()
+        return laser_data
+
+    def get_pose3d(self):
+        if self.pose3d_node is None:
+            return None
+        return self.pose3d_node.getPose3d()
+
+    def update_gui(self):
         lapped = self.lap.check_threshold()
-        lap_message = ""
         if lapped is not None:
             self.payload["lap"] = str(lapped)
-
-        # Payload Map Message
+            
         map_message = self.map.get_json_data()
         self.payload["map"] = map_message
-
+        
         message = json.dumps(self.payload)
         self.send_to_client(message)
 
     def showForces(self, vec1, vec2, vec3):
-        """Function for student to call"""
         self.map.setCar(vec1[0], vec1[1])
         self.map.setObs(vec2[0], vec2[1])
         self.map.setAvg(vec3[0], vec3[1])
 
     def showLocalTarget(self, newVec):
-        """Function for student to call"""
         self.map.setTargetPos(newVec[0], newVec[1])
 
     def reset_gui(self):
-        """Resets the GUI to its initial state."""
         self.map.reset()
         self.lap.reset()
 
+    def __del__(self):
+        try:
+            if self.executor:
+                self.executor.shutdown()
+        except Exception:
+            pass
 
 host = "ws://127.0.0.1:2303"
 gui = WebGUI(host)
 
-# Redirect the console
 start_console()
-
 
 def showForces(vec1, vec2, vec3):
     gui.showForces(vec1, vec2, vec3)
 
-
 def showLocalTarget(newVec):
     return gui.showLocalTarget(newVec)
-
-
-# TODO: change this to another file, not GUI
-
 
 def getNextTarget():
     return gui.map.getNextTarget()
 
-
 def setTargetx(x):
     gui.map.targetx = x
-
 
 def setTargety(y):
     gui.map.targety = y


### PR DESCRIPTION
Closes #3237 

The user is able to not interact with WebGUI or HAL directly, everything can be done via pub/sub.

The main input is `/webgui/current_target` (`geometry_msgs/msg/Point`). The node subscribes to it with `TRANSIENT_LOCAL` QoS

When the robot reaches the target  the user must publish `True` to `/webgui/target_reached` (`std_msgs/msg/Bool`). This makes the GUI send the next target automatically.

For debugging, the node can publish force vectors to:
- `/webgui/force/car` → attractive force (towards target)
- `/webgui/force/obs` → repulsive force (obstacles)
- `/webgui/force/avg` → resulting force

All of them use `geometry_msgs/msg/Point` and are visualized in the GUI

The `/webgui/local_target` topic can be used to update the target shown in the GUI

/odom and /cmd_vel for getting the car pose and controlling in vel the vehicle