### PR TITLE
ros2-direct support for global nav

### DIFF
--- a/exercises/global_navigation/python_template/WebGUI.py
+++ b/exercises/global_navigation/python_template/WebGUI.py
@@ -3,14 +3,55 @@ import base64
 import re
 import json
 import threading
+import sys
 import numpy as np
 
+import rclpy
+from rclpy.node import Node
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.qos import QoSProfile, DurabilityPolicy
+from geometry_msgs.msg import Point
+from nav_msgs.msg import Path
+from sensor_msgs.msg import Image as ROSImage
+
+from hal_interfaces.general.odometry import OdometryNode
 from gui_interfaces.general.measuring_threading_gui import MeasuringThreadingGUI
 from console_interfaces.general.console import start_console
 from map import Map
-from HAL import getPose3d
 
-# Graphical User Interface Class
+
+class ROS2BridgeNode(Node):
+    def __init__(self, gui_instance):
+        super().__init__("gui_bridge_node")
+        self.gui = gui_instance
+        
+        qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.target_pub = self.create_publisher(Point, "/webgui/current_target", qos)
+        
+        self.create_subscription(Path, "/webgui/path", self.path_callback, 10)
+        self.create_subscription(ROSImage, "/webgui/debug_image", self.image_callback, 10)
+
+    def path_callback(self, msg):
+        path_array = []
+        for pose_stamped in msg.poses:
+            grid_x, grid_y = self.gui.map.worldToGrid(
+                pose_stamped.pose.position.x, 
+                pose_stamped.pose.position.y
+            )
+            path_array.append([grid_x, grid_y])
+        self.gui.showPath(path_array)
+
+    def image_callback(self, msg):
+        try:
+            data = np.frombuffer(msg.data, dtype=np.uint8)
+            image = data.reshape((msg.height, msg.width))
+            self.gui.showNumpy(image)
+        except Exception:
+            pass
+
+    def publish_target(self, x, y):
+        msg = Point(x=float(x), y=float(y), z=0.0)
+        self.target_pub.publish(msg)
 
 
 class WebGUI(MeasuringThreadingGUI):
@@ -25,16 +66,43 @@ class WebGUI(MeasuringThreadingGUI):
         self.image_to_be_shown_updated = False
         self.image_show_lock = threading.Lock()
 
-        # Payload vars
         self.payload = {"image": "", "map": "", "array": ""}
-        self.map = Map(getPose3d)
+        
+        self.pose3d_node = None
+        self.bridge_node = None
+        self.executor = None
+        self.executor_thread = None
+
+        self._setup_ros2()
+        
+        self.map = Map(self.get_pose3d)
 
         self.start()
 
-    # Process incoming messages to the GUI
-    def gui_in_thread(self, ws, message):
+    def _setup_ros2(self):
+        if not rclpy.ok():
+            rclpy.init()
+            
+        self.pose3d_node = OdometryNode("/odom")
+        self.bridge_node = ROS2BridgeNode(self)
+        
+        self.executor = MultiThreadedExecutor()
+        self.executor.add_node(self.pose3d_node)
+        self.executor.add_node(self.bridge_node)
+        
+        self.executor_thread = threading.Thread(
+            target=self.executor.spin,
+            daemon=True,
+            name="webgui_ros2_executor"
+        )
+        self.executor_thread.start()
 
-        # In this case, incoming msgs can only be acks
+    def get_pose3d(self):
+        if self.pose3d_node is None:
+            return None
+        return self.pose3d_node.getPose3d()
+
+    def gui_in_thread(self, ws, message):
         if "ack" in message:
             with self.ack_lock:
                 self.ack = True
@@ -46,15 +114,15 @@ class WebGUI(MeasuringThreadingGUI):
             self.mapXY = data
             x, y = self.mapXY
             self.worldXY = self.map.gridToWorld(x, y)
+            if self.bridge_node is not None:
+                self.bridge_node.publish_target(self.worldXY[0], self.worldXY[1])
 
-    # Prepares and sends a map to the websocket server
     def update_gui(self):
-
         payload = self.payloadImage()
         self.payload["image"] = json.dumps(payload)
 
         self.payload["array"] = self.array
-        # Payload Map Message
+        
         pos_message1 = self.map.getTaxiCoordinates()
         ang_message = self.map.getTaxiAngle()
         pos_message = str(pos_message1 + ang_message)
@@ -63,8 +131,6 @@ class WebGUI(MeasuringThreadingGUI):
         message = json.dumps(self.payload)
         self.send_to_client(message)
 
-    # Function to prepare image payload
-    # Encodes the image as a JSON string and sends through the WS
     def payloadImage(self):
         with self.image_show_lock:
             image_to_be_shown_updated = self.image_to_be_shown_updated
@@ -95,11 +161,9 @@ class WebGUI(MeasuringThreadingGUI):
             self.image_to_be_shown_updated = True
 
     def showPath(self, array):
-        """Process the array(ideal path) to be sent to websocket"""
         with self.array_lock:
             strArray = "".join(str(e) for e in array)
 
-            # Remove unnecessary spaces in the array to avoid JSON syntax error in JavaScript
             strArray = re.sub(r"\[[ ]+", "[", strArray)
             strArray = re.sub(r"[ ]+", ", ", strArray)
             strArray = re.sub(r",[ ]+]", "]", strArray)
@@ -125,49 +189,44 @@ class WebGUI(MeasuringThreadingGUI):
         return self.map.gridToWorld(*cell)
 
     def reset_gui(self):
-        """Resets the GUI to its initial state."""
-        print("Resetting image")
         image = [[0 for x in range(400)] for y in range(400)]
         self.showNumpy(np.clip(image, 0, 255).astype("uint8"))
         self.map.reset()
+        
+    def __del__(self):
+        try:
+            if self.executor:
+                self.executor.shutdown()
+        except Exception:
+            pass
 
 
 host = "ws://127.0.0.1:2303"
 gui = WebGUI(host)
 
-# Redirect the console
 start_console()
 
 
-# Expose to the user
 def payloadImage():
     return gui.payloadImage()
-
 
 def showNumpy(image):
     gui.showNumpy(image)
 
-
 def showPath(array):
     gui.showPath(array)
-
 
 def getTargetPose():
     return gui.getTargetPose()
 
-
 def getMap(url):
     return gui.getMap(url)
 
-
 def rowColumn(pose):
-    # Deprecated. Still alive for backward compatibility.
     return list(gui.worldToGrid(pose))
-
 
 def worldToGrid(pose):
     return gui.worldToGrid(pose)
-
 
 def gridToWorld(cell):
     return gui.gridToWorld(cell)


### PR DESCRIPTION
Closes #3615 
The user can communicate with the GUI and the robot using pub/sub, without relying on WebGUI or HAL abstractions.

## WebGUI Interaction Topics

### `/webgui/current_target`
- **Subscribe**
- `geometry_msgs/msg/Point`
- QoS: `depth=1`, `TRANSIENT_LOCAL`
- Provides the target (x, y) selected in the GUI.
- The last target is received immediately after subscribing.

### `/webgui/path`
- **Publish**
- `nav_msgs/msg/Path`
- Sends the computed path to the GUI for visualization.
- Coordinates must be in world frame.

### `/webgui/debug_image`
- **Publish**
- `sensor_msgs/msg/Image`
- Used to visualize cost maps or intermediate algorithm states.
- Typically `mono8` with values normalized to `[0, 255]`.

## Robot Topics

### `/odom`
- **Subscribe**
- `nav_msgs/msg/Odometry`
- Provides robot pose.
- Orientation must be converted from quaternion to yaw.

### `/cmd_vel`
- **Publish**
- `geometry_msgs/msg/Twist`
- Controls robot motion:
  - `linear.x` → forward velocity
  - `angular.z` → rotation

- Wait for a target from `/webgui/current_target`
- Compute the path using the selected algorithm
- Publish the path to `/webgui/path`
- Optionally publish debug information (`/webgui/debug_image`)
- Use `/odom` to track the robot and `/cmd_vel` to move it if required