### PR TITLE
fix(scripts): fix getopts bug, add preflight checks and help option in run_academy.sh

### DIFF
--- a/scripts/run_academy.sh
+++ b/scripts/run_academy.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
-
 # Default: cpu and offline
 gpu_mode="false"
 nvidia="false"
 base_path_offline="compose_cfg/"
 compose_file="user_humble_cpu"
 base_path_online="https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/humble-devel/compose_cfg/"
+
+# Function to display usage information
+show_help() {
+  echo "Usage: $(basename "$0") [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  -g  Enable GPU mode (uses user_humble_gpu compose file)"
+  echo "  -n  Enable Nvidia support (uses user_humble_nvidia compose file)"
+  echo "  -h  Display this help message"
+  echo ""
+  echo "Examples:"
+  echo "  $(basename "$0")          # Run in CPU mode (default)"
+  echo "  $(basename "$0") -g       # Run in GPU mode"
+  echo "  $(basename "$0") -n       # Run with Nvidia support"
+}
 
 # Function to clean up the containers
 cleanup() {
@@ -15,24 +29,49 @@ cleanup() {
   else
     docker compose down
   fi
-  rm docker-compose.yaml
-  
+  if [ -f docker-compose.yaml ]; then
+    rm docker-compose.yaml
+  fi
   exit 0
 }
 
-# Loop through the arguments using a while loop
-while getopts ":g:n  " opt; do
+# Preflight checks
+preflight_checks() {
+  if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is not installed or not in PATH. Please install Docker first."
+    echo "See: https://docs.docker.com/engine/install/"
+    exit 1
+  fi
+
+  if ! docker compose version &> /dev/null; then
+    echo "Error: Docker Compose V2 is not installed."
+    echo "See: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+
+  if ! docker info &> /dev/null; then
+    echo "Error: Docker daemon is not running. Please start Docker."
+    exit 1
+  fi
+}
+
+# Loop through the arguments
+while getopts ":gnh" opt; do
   case $opt in
-    g) gpu_mode="true" ;; 
+    g) gpu_mode="true" ;;
     n) nvidia="true" ;;
-    \?) echo "Invalid option: -$OPTARG" >&2 ;;   # If an invalid option is provided, print an error message
+    h) show_help; exit 0 ;;
+    \?) echo "Error: Invalid option: -$OPTARG" >&2; show_help; exit 1 ;;
   esac
 done
+
+# Run preflight checks before doing anything else
+preflight_checks
 
 # Set up trap to catch interrupt signal (Ctrl+C) and execute cleanup function
 trap 'cleanup' INT
 
-# Set the compose file
+# Set the compose file based on flags
 if [ "$gpu_mode" = "true" ]; then
   compose_file="user_humble_gpu"
 fi
@@ -40,13 +79,22 @@ if [ "$nvidia" = "true" ]; then
   compose_file="user_humble_nvidia"
 fi
 
-# Check the mode
+# Check the mode (offline if compose_cfg dir exists, online otherwise)
 if [ -d compose_cfg ]; then
   # Offline mode
-  cp $base_path_offline$compose_file.yaml docker-compose.yaml
+  cp "$base_path_offline$compose_file.yaml" docker-compose.yaml
 else
-  # Online mode
-  curl -sL $base_path_online$compose_file.yaml -o docker-compose.yaml
+  # Online mode: fetch compose file and verify it was downloaded correctly
+  echo "compose_cfg/ not found, fetching compose file from upstream..."
+  curl -sL "$base_path_online$compose_file.yaml" -o docker-compose.yaml
+
+  if [ $? -ne 0 ] || [ ! -s docker-compose.yaml ]; then
+    echo "Error: Failed to download compose file from:"
+    echo "  $base_path_online$compose_file.yaml"
+    echo "Check your internet connection or run from the repo root directory."
+    rm -f docker-compose.yaml
+    exit 1
+  fi
 fi
 
 # Execute docker compose


### PR DESCRIPTION
## Summary

Fixes #3619

`scripts/run_academy.sh` had several robustness issues that caused silent failures
or confusing behavior. This PR fixes all issues identified in the bug report.

## Changes

### 1. Fix broken `getopts` option string
**Before:** `while getopts ":g:n  " opt`
**After:** `while getopts ":gnh" opt`

The original `g:` syntax incorrectly marked `-g` as expecting an argument,
causing it to silently consume the next token (e.g. `-n`) instead of treating
both as boolean flags. Trailing spaces in the option string were also invalid.

### 2. Add `preflight_checks()` function
Validates the environment before attempting any Docker operations:
- Docker is installed and in PATH
- Docker Compose V2 is available (`docker compose version`)
- Docker daemon is running (`docker info`)

Produces clear, actionable error messages with documentation links on failure.
This matches the partial check already present in `develop_academy.sh` and
extends it with daemon availability detection.

### 3. Add `show_help()` and `-h` flag
Provides usage information and examples, consistent with the existing pattern
in `develop_academy.sh`. Invalid flags now print help and exit cleanly instead
of silently continuing.

### 4. Add `curl` error handling in online mode
**Before:** A failed download silently wrote an empty/broken `docker-compose.yaml`,
causing a cryptic `docker compose up` failure with no clear cause.

**After:** Checks both the `curl` exit code and the output file size. On failure,
prints the attempted URL, removes the broken file, and exits with a clear message.

### 5. Quote all variable expansions
Prevents word splitting on paths containing spaces.

## Testing
```bash
# Test help flag
./scripts/run_academy.sh -h

# Test invalid flag handling
./scripts/run_academy.sh -x

# Test preflight check (stop Docker daemon first)
sudo systemctl stop docker && ./scripts/run_academy.sh
sudo systemctl start docker

# Test normal CPU mode
./scripts/run_academy.sh
```

## Before / After

| Scenario | Before | After |
|---|---|---|
| `./run_academy.sh -g -n` | `-n` silently consumed as arg to `-g` | Both flags set correctly |
| Docker not installed | Cryptic failure at `docker compose up` | Clear error + docs link |
| Docker daemon stopped | Cryptic failure | "Docker daemon is not running" |
| No internet, no `compose_cfg/` | Empty yaml, confusing compose error | Clear download failure message |
| `./run_academy.sh -h` | "Invalid option" | Prints usage and examples |