### PR TITLE
Clarify C++ execution model

### DIFF
--- a/_pages/exercises/AutonomousCars/follow_line.md
+++ b/_pages/exercises/AutonomousCars/follow_line.md
@@ -102,7 +102,19 @@ This exercise now supports ROS 2-native implementation in addition to the origin
 - `HAL::get_image();` - to get the image (cv::Mat).
 - `HAL::set_v(velocity);` - to set the linear speed.
 - `HAL::set_w(velocity);` - to set the angular velocity.
-- `WebGUI::show_image(image);` - allows you to view a debug image (cv::Mat) or with relevant information.
+- `WebGUI::show_image(image);` - allows you to view a debug image (cv::Mat) or with relevant information
+
+**Note**:
+- In C++ files, you should **NOT define your own `main()` function**.
+- The framework already provides a `main.cpp` which internally calls a function named `exercise()`.
+- You must implement your logic inside:
+```cpp
+void exercise() {
+
+    while (true) {
+
+    }
+}
 
 ### ROS 2-direct Implementation
 

--- a/_pages/exercises/MobileRobots/vacuum_cleaner.md
+++ b/_pages/exercises/MobileRobots/vacuum_cleaner.md
@@ -109,6 +109,18 @@ if len(laser_data.values) > 0:
 * `HAL::set_w(velocity);` - to set the angular velocity.
 * `HAL::get_bumper_data();` - to get the bumper state from the robot. Returns a vector of booleans with the next order: Right, Center, Left.
 
+**Note**:
+- In C++ files, you should **NOT define your own `main()` function**.
+- The framework already provides a `main.cpp` which internally calls a function named `exercise()`.
+- You must implement your logic inside:
+```cpp
+void exercise() {
+
+    while (true) {
+
+    }
+}
+
 ### ROS 2-direct Implementation
 
 #### ROS 2 Topics


### PR DESCRIPTION
### Description

Clarifies the execution model for C++ exercises.

Adds a note explaining that users should not define their own `main()` and must implement `void exercise()`, as the framework already provides `main.cpp`.

### Why

This is a common source of confusion and often leads to errors like multiple `main()` definitions or missing `exercise()`.

### Changes

- Added note under HAL-based C++ section
- Included minimal example