### PR TITLE
fix(scripts): fix undefined Help call, docker compose check, and unquoted variables in develop_academy.sh

### DIFF
--- a/scripts/develop_academy.sh
+++ b/scripts/develop_academy.sh
@@ -61,7 +61,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Invalid Option: $1"
-            Help
+            show_help
             exit 1
             ;;
    esac
@@ -75,13 +75,13 @@ echo "RAM branch: $branch"
 echo "RoboticsBackend version: $radi_version"
 
 # Check docker compose installation
-if ! command -v docker compose &> /dev/null; then
+if ! docker compose version &> /dev/null; then
   echo "Docker Compose V2 is not installed. Please install it."
 fi
 
 # Clone the desired RAM fork and branch
 if ! [ -d src ]; then
-  git clone $ram_version -b $branch src;
+  git clone "$ram_version" -b "$branch" src;
   chown -R $(id -u):$(id -g) src/
 fi
 


### PR DESCRIPTION
## Summary

Fixes #3633

`scripts/develop_academy.sh` had three bugs causing silent failuresor crashes during developer environment setup.

## Changes

### 1. Fix undefined function `Help` on invalid option
**Before:** `Help` (line 64)
**After:** `show_help` (line 64)

The wildcard case in the argument parser called `Help` which does not exist — the correct function defined at line 12 is `show_help`. This caused a `command not found` crash whenever an invalid option was passed instead of printing usage information.

### 2. Fix incorrect Docker Compose V2 detection
**Before:** `if ! command -v docker compose &> /dev/null`
**After:** `if ! docker compose version &> /dev/null`

`command -v` checks for a standalone binary in PATH. DockerCompose V2 is a Docker CLI plugin — not a standalone binary —so `command -v docker compose` always returns true regardless of whether Compose V2 is actually installed. The correct check is `docker compose version` which invokes the plugin directly.

This fix is consistent with the approach already used in `run_academy.sh` (PR #3620).

### 3. Quote variable expansions in `git clone`
**Before:** `git clone $ram_version -b $branch src`
**After:** `git clone "$ram_version" -b "$branch" src`

Unquoted variables are subject to word splitting by the shell. While unlikely in practice for URLs, this is a shell scripting best practice and prevents subtle failures if branch names or URLs contain spaces or special characters.

## Testing
```bash
# Bug 1: invalid option now shows help instead of crashing
./scripts/develop_academy.sh -z

# Bug 2: docker compose check now correctly detects V2
./scripts/develop_academy.sh -h

# Bug 3: branch names with spaces now handled correctly
./scripts/develop_academy.sh -b "my-branch"
```

## Related
- Consistent with fixes applied to `run_academy.sh` in PR #3620
- Fixes #3633