### PR TITLE
fix(file_access): fix ResourceAlreadyExists not raised for existing directories in FAL.create

### DIFF
--- a/academy/file_access.py
+++ b/academy/file_access.py
@@ -73,7 +73,7 @@ class FAL(ABC):
         if ".." in path:
             raise InvalidPath(path)
 
-        if self.exists(path) > 0:
+        if self.exists(path) != -1:
             raise ResourceAlreadyExists(path)
 
     @abstractmethod
@@ -82,7 +82,7 @@ class FAL(ABC):
         if ".." in path:
             raise InvalidPath(path)
 
-        if self.exists(path) > 0:
+        if self.exists(path) != -1:
             raise ResourceAlreadyExists(path)
 
     @abstractmethod


### PR DESCRIPTION
## Summary

Fixes #3646

## Bug

`FAL.create` and `FAL.create_binary` in `academy/file_access.py` used an incorrect condition to check if a path already exists:
```python
# Before (incorrect)
if self.exists(path) > 0:
    raise ResourceAlreadyExists(path)
```

`exists()` returns:
- `-1` → path does not exist
- `0` → path is an existing **directory**
- `> 0` → path is an existing **file** (returns file size)

The condition `> 0` only catches existing files, completely missing existing directories. Calling `create()` with a path pointing to an existing directory would not raise `ResourceAlreadyExists` — instead it would propagate an unhandled `IsADirectoryError`.

## Fix
```python
# After (correct)
if self.exists(path) != -1:
    raise ResourceAlreadyExists(path)
```

This correctly catches both existing files (`> 0`) and existing directories (`== 0`).

## Discovery

This bug was discovered while writing unit tests for `FAL_RA` in PR #3638. The test `test_create_raises_if_exists` initially failed because `ResourceAlreadyExists` was not being raised when a directory existed at the target path.