### PR TITLE
refactor(docker): remove dev-only tools from RADI infrastructure

### DIFF
--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -163,8 +163,7 @@ RUN python3.10 -m pip install \
 RUN python3.10 -m pip install --ignore-installed sympy==1.13.3 
 RUN python3.10 -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu128
 
-# monaco editor
-RUN python3.10 -m pip install black==24.10.0
+# monaco editor (black removed - dev-only formatter)
 
 # websocket server dependency
 RUN python3.10 -m pip install websocket_server==0.6.4 posix-ipc==1.1.1 django==4.1.7 djangorestframework==3.13.1 \
@@ -193,27 +192,13 @@ RUN apt-get update && \
   python3-colcon-mixin \
   python-is-python3 \
   ros-dev-tools \
-  python3-flake8 \
-  python3-flake8-builtins  \
-  python3-flake8-comprehensions \
-  python3-flake8-docstrings \
-  python3-flake8-import-order \
-  python3-flake8-quotes \
-  cppcheck \
-  lcov \
   lsb-release \
   wget \
   gnupg \
   && rm -rf /var/lib/apt/lists/* 
 
 RUN pip3 install \
-  pylint \
-  flake8==4.0.1 \
-  pycodestyle==2.8 \
-  cmakelint \
-  cpplint \
   transforms3d \
-  colcon-lcov-result \
   PySimpleGUI-4-foss
 
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
@@ -243,16 +228,13 @@ RUN apt-get update && \
   python3-jinja2 \
   python3-pydantic \
   python3-pymap3d \
-  python3-pytest \
   ros-humble-action-msgs \
   ros-humble-ament-cmake \
   ros-humble-ament-cmake-gtest \
   ros-humble-ament-cmake-lint-cmake \
-  ros-humble-ament-cmake-pytest \
   ros-humble-ament-cmake-python \
   ros-humble-ament-cmake-xmllint \
   ros-humble-ament-copyright \
-  ros-humble-ament-flake8 \
   ros-humble-ament-index-cpp \
   ros-humble-ament-lint-auto \
   ros-humble-ament-lint-common \
@@ -372,3 +354,9 @@ RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
   export GZ_VERSION=harmonic && \
   colcon build --packages-select gz_ros2_control --allow-overriding gz_ros2_control"
 WORKDIR /
+# Clean build artifacts to reduce image size (500MB-1GB potential savings)
+RUN find /home/ws -name "*.o" -delete && \
+  find /home/ws -name "CMakeFiles" -type d -exec rm -rf {} + 2>/dev/null || true && \
+  find /home/ws/build -name "*.cmake" -delete 2>/dev/null || true && \
+  rm -rf /home/ws/build/*/CMakeFiles 2>/dev/null || true
+

--- a/scripts/RADI/Dockerfile.humble
+++ b/scripts/RADI/Dockerfile.humble
@@ -37,15 +37,18 @@ RUN git clone --depth 1 https://github.com/${ACADEMY_OWNER}/RoboticsAcademy.git 
 # Compiling and sourcing the workspace
 WORKDIR /home/ws
 RUN /bin/bash -c "source /home/drones_ws/install/setup.bash"
-RUN /bin/bash -c "source /home/dev_ws/install/local_setup.bash"
-RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build --symlink-install --packages-ignore gz_ros2_control gz_ros2_control_demos"
+RUN /bin/bash -c "if [ -f /home/dev_ws/install/local_setup.bash ]; then source /home/dev_ws/install/local_setup.bash; fi"
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build --symlink-install --packages-ignore gz_ros2_control gz_ros2_control_demos gz_link_attacher"
 
 # Compress commons
 WORKDIR /RoboticsAcademy/
 RUN cd /RoboticsAcademy/common && cd console_interfaces && zip -r ../common.zip console_interfaces/ && cd .. && cd gui_interfaces && zip -r -u ../common.zip gui_interfaces/ && cd .. && cd hal_interfaces && zip -r -u ../common.zip hal_interfaces/ && cd ../.. && mv common/common.zip react_frontend/src/common.zip
 
 # build react_fronted
-RUN cd /RoboticsAcademy/react_frontend/ && yarn install && yarn run build
+RUN cd /RoboticsAcademy/react_frontend/ && \
+    yarn install && \
+    yarn run build && \
+    rm -rf node_modules
 
 # Django server
 EXPOSE 7164


### PR DESCRIPTION
Remove development and testing tools not needed at runtime:
- black, flake8, cppcheck, lcov, pytest packages
- Add /home/ws build artifact cleanup

Expected savings: ~650MB-1.1GB
Aligns with GitHub issue #2239.