### PR TITLE
docs(hal_interfaces): add docstrings to CameraNode, MotorsNode, OdometryNode and helper classes

### DIFF
--- a/common/hal_interfaces/hal_interfaces/general/camera.py
+++ b/common/hal_interfaces/hal_interfaces/general/camera.py
@@ -16,6 +16,8 @@ MINRANGE = 0
 
 
 class Image:
+    """Represents a camera image with metadata and pixel data."""
+
     def __init__(self):
 
         self.height = 480  # Image height [pixels]
@@ -40,6 +42,16 @@ class Image:
 
 
 def imageMsg2Image(img, bridge):
+    """
+    Convert a ROS Image message to a JdeRobot Image object.
+
+    Args:
+        img: ROS sensor_msgs/Image message.
+        bridge: cv_bridge.CvBridge instance for conversion.
+
+    Returns:
+        Image object with BGR data, or None if the message is empty.
+    """
 
     if len(img.data) == 0:
         return None
@@ -63,6 +75,8 @@ def imageMsg2Image(img, bridge):
 
 ### HAL INTERFACE ###
 class CameraNode(Node):
+    """ROS2 node that subscribes to a camera topic and stores the latest image."""
+
     def __init__(self, topic):
         super().__init__("camera_node")
         self.sub = self.create_subscription(
@@ -72,7 +86,14 @@ class CameraNode(Node):
         self.bridge_ = cv_bridge.CvBridge()
 
     def listener_callback(self, msg):
+        """Store the latest image message received from the topic."""
         self.last_img_ = msg
 
     def getImage(self):
+        """
+        Return the latest camera image.
+
+        Returns:
+            Image object with BGR data, or None if no image has been received.
+        """
         return imageMsg2Image(self.last_img_, self.bridge_)

--- a/common/hal_interfaces/hal_interfaces/general/motors.py
+++ b/common/hal_interfaces/hal_interfaces/general/motors.py
@@ -8,6 +8,8 @@ if not rclpy.ok():
 
 ### HAL INTERFACE ###
 class MotorsNode(Node):
+    """ROS2 node that publishes linear and angular velocity commands to a robot."""
+
     def __init__(self, topic, maxV, maxW):
 
         super().__init__("motors_node")
@@ -15,9 +17,19 @@ class MotorsNode(Node):
         self.last_twist = Twist()
 
     def sendV(self, v):
+        """Publish a linear velocity command.
+
+        Args:
+            v (float): Linear velocity in m/s.
+        """
         self.last_twist.linear.x = v
         self.pub.publish(self.last_twist)
 
     def sendW(self, w):
+        """Publish an angular velocity command.
+
+        Args:
+            w (float): Angular velocity in rad/s.
+        """
         self.last_twist.angular.z = w
         self.pub.publish(self.last_twist)

--- a/common/hal_interfaces/hal_interfaces/general/odometry.py
+++ b/common/hal_interfaces/hal_interfaces/general/odometry.py
@@ -9,6 +9,8 @@ if not rclpy.ok():
 
 ### AUXILIARY FUNCTIONS ###
 class Pose3d:
+    """Represents a 3D pose with position, orientation, and timestamp."""
+
     def __init__(self):
 
         self.x = 0  # X coord [meters]
@@ -131,7 +133,14 @@ class OdometryNode(Node):
         self.last_pose_ = nav_msgs.msg.Odometry()
 
     def listener_callback(self, msg):
+        """Store the latest odometry message received from the topic."""
         self.last_pose_ = msg
 
     def getPose3d(self):
+        """
+        Return the latest pose as a Pose3d object.
+
+        Returns:
+            Pose3d with position, orientation, and timestamp fields populated.
+        """
         return odometry2Pose3D(self.last_pose_)


### PR DESCRIPTION
## Summary

Fixes #3666, Addresses #3111

Adds missing docstrings to the core HAL interface classes in `common/hal_interfaces/`. These classes are used as the base for every exercise in RoboticsAcademy.

## Changes

### `camera.py`
- `Image` class docstring
- `imageMsg2Image()`: args, return type, None case documented
- `CameraNode` class docstring
- `listener_callback()`: purpose documented
- `getImage()`: return type and None case documented

### `motors.py`
- `MotorsNode` class docstring
- `sendV()`: arg type and units (m/s) documented
- `sendW()`: arg type and units (rad/s) documented

### `odometry.py`
- `Pose3d` class docstring
- `OdometryNode` class docstring
- `listener_callback()`: purpose documented
- `getPose3d()`: return type documented