### PR TITLE
tests(templates): add unit tests for select_template function

### DIFF
--- a/academy/tests.py
+++ b/academy/tests.py
@@ -21,7 +21,7 @@ from academy.exceptions import (
 )
 from academy.file_access import FAL_RA
 from academy.models import Exercise, Universe, World, Robot, Tool
-
+from academy.templates import select_template
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -380,3 +380,57 @@ class FileManagementViewTests(TestCase):
             },
         )
         self.assertEqual(response.status_code, 403)
+
+
+class TemplateTests(TestCase):
+    """Tests for academy/templates.py select_template function."""
+
+    def test_py_reactive_returns_nonempty(self):
+        result = select_template("py-reactive")
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+
+    def test_py_ros2_returns_nonempty(self):
+        result = select_template("py-ros2")
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+
+    def test_cpp_reactive_returns_nonempty(self):
+        result = select_template("cpp-reactive")
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+
+    def test_cpp_ros2_returns_nonempty(self):
+        result = select_template("cpp-ros2")
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+
+    def test_unknown_template_returns_empty_string(self):
+        self.assertEqual(select_template("unknown"), "")
+
+    def test_empty_string_returns_empty_string(self):
+        self.assertEqual(select_template(""), "")
+
+    def test_py_reactive_contains_expected_keywords(self):
+        result = select_template("py-reactive")
+        self.assertIn("HAL", result)
+        self.assertIn("WebGUI", result)
+        self.assertIn("Frequency", result)
+        self.assertIn("while True", result)
+
+    def test_py_ros2_contains_expected_keywords(self):
+        result = select_template("py-ros2")
+        self.assertIn("rclpy", result)
+        self.assertIn("Node", result)
+        self.assertIn("WebGUI", result)
+
+    def test_cpp_reactive_contains_expected_keywords(self):
+        result = select_template("cpp-reactive")
+        self.assertIn("HAL.hpp", result)
+        self.assertIn("WebGUI.hpp", result)
+        self.assertIn("Frequency.hpp", result)
+
+    def test_cpp_ros2_contains_expected_keywords(self):
+        result = select_template("cpp-ros2")
+        self.assertIn("rclcpp", result)
+        self.assertIn("Node", result)


### PR DESCRIPTION
## Summary

`academy/templates.py` was added in PR #3661 but shipped with no unit tests. This PR adds 10 tests covering the 
`select_template()` function and all four template generators.

## Tests added

- `test_py_reactive_returns_nonempty`
- `test_py_ros2_returns_nonempty`
- `test_cpp_reactive_returns_nonempty`
- `test_cpp_ros2_returns_nonempty`
- `test_unknown_template_returns_empty_string`
- `test_empty_string_returns_empty_string`
- `test_py_reactive_contains_expected_keywords`
- `test_py_ros2_contains_expected_keywords`
- `test_cpp_reactive_contains_expected_keywords`
- `test_cpp_ros2_contains_expected_keywords`