### PR TITLE
Fix: develop_academy.sh defaults to CPU mode even when NVIDIA GPU is present

### DIFF
--- a/scripts/develop_academy.sh
+++ b/scripts/develop_academy.sh
@@ -61,11 +61,25 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Invalid Option: $1"
+            echo "Note: If you meant to enable NVIDIA GPU support, use -n (not --nvidia)"
             Help
             exit 1
             ;;
    esac
 done
+
+# --- Auto-detect GPU if no flag was explicitly provided ---
+if [ "$nvidia" = "false" ] && [ "$gpu_mode" = "false" ]; then
+  if nvidia-smi > /dev/null 2>&1; then
+    echo "[INFO] NVIDIA GPU detected. Enabling NVIDIA mode automatically. Use -g to force generic GPU mode or run without GPU flags for CPU mode."
+    nvidia="true"
+  elif [ -e /dev/dri ]; then
+    echo "[INFO] GPU device found at /dev/dri. Enabling GPU mode automatically."
+    gpu_mode="true"
+  else
+    echo "[INFO] No GPU detected. Running in CPU-only mode."
+  fi
+fi
 
 # Set up trap to catch interrupt signal (Ctrl+C) and execute cleanup function
 trap 'cleanup' INT


### PR DESCRIPTION
## Problem
`develop_academy.sh` always defaults to CPU mode (`dev_humble_cpu.yaml`) even when 
an NVIDIA GPU is available. The only way to enable GPU acceleration was by passing 
the `-n` flag manually, which is not prominent in the docs. Attempting `--nvidia` 
(the intuitive guess) throws `Invalid Option` with no helpful message.

This causes:
- VNC server failure: `Port 5901 on localhost didn't become available within 120 seconds`
- `GPU: OFF` shown in the exercise UI  
- ~6% RTF making simulation nearly unusable
- No clear error pointing to the fix

By contrast, `run_academy.sh` already auto-detects NVIDIA using `nvidia-smi`. 
This PR brings `develop_academy.sh` to parity.

## Fix
- Added GPU auto-detection after argument parsing: checks `nvidia-smi` first, 
  falls back to `/dev/dri` generic GPU, then CPU-only with clear messages
- Manual flags (`-n`, `-g`) still take priority over auto-detection
- Added hint to invalid option error pointing users to `-n` instead of `--nvidia`

## Testing
Tested on Pop!_OS with NVIDIA GeForce RTX 3050 6GB Laptop GPU.
- Before: `GPU: OFF`, VNC timeout after 120s
- After: `[INFO] NVIDIA GPU detected...` printed, `GPU: NVIDIA` shown in UI
<img width="1920" height="1080" alt="gpu_nvidia_proof" src="https://github.com/user-attachments/assets/e3e16ee2-5dfa-4cba-a0be-019eefb840a5" />
