### PR TITLE
docs: fix GripperSet percentage semantics (0=open, 100=closed)

### DIFF
--- a/exercises/machine_vision/python_template/HAL.py
+++ b/exercises/machine_vision/python_template/HAL.py
@@ -832,7 +832,7 @@ def detach():
 
 
 def GripperSet(relative_closure, wait_time):
-    """Set gripper closure percentage (100% full open, 0% full closed)"""
+    """Set gripper closure percentage (0% fully open, 100% fully closed)"""
     ACTION = Action()
     ACTION.action = "MoveG"
     ACTION.speed = float(1)  # Gripper speed not working for Robotiq 85, set to 100%
@@ -878,7 +878,7 @@ def back_to_home():
     """Move robot back to home position"""
     print("Moving robot back to home position...")
     MoveAbsJ(_home_joints, 0.9, 1.0)
-    GripperSet(0, 0.5)  # 100% open (full release)
+    GripperSet(0, 0.5)  # 0% closed (fully open / full release)
     print("Robot returned to home position")
 
 

--- a/exercises/pick_place/python_template/HAL.py
+++ b/exercises/pick_place/python_template/HAL.py
@@ -334,7 +334,7 @@ def dettach():
     )
 
 
-# Gripper closing and opeining to a given percentage (100% full open, 0% full closed)
+# Set gripper closure to a given percentage (0% fully open, 100% fully closed)
 # Speed max 1.0, wait time after movement in seconds
 def GripperSet(relative_closure, wait_time):
     ACTION = Action()


### PR DESCRIPTION
Fixes #3567.

The `GripperSet()` helpers in the Machine Vision and Pick&Place python templates had contradictory documentation/comments about what `relative_closure` means.

- Clarify semantics: **0% = fully open** (full release), **100% = fully closed**.
- Update the `back_to_home()` comment to match actual behavior.

Testing:
- `python -m py_compile exercises/machine_vision/python_template/HAL.py exercises/pick_place/python_template/HAL.py