### PR TITLE
fix(object_detection): fix bugs in benchmarking utilities

### DIFF
--- a/exercises/object_detection/benchmarking/BoundingBox.py
+++ b/exercises/object_detection/benchmarking/BoundingBox.py
@@ -35,7 +35,7 @@ class BoundingBox:
         # If relative coordinates, convert to absolute values
         # For relative coords: (x,y,w,h)=(X_center/img_width , Y_center/img_height)
         if typeCoordinates == CoordinatesType.Relative:
-            (self._x, self._y, self._w, self._h) = convertToAbsoluteValues(
+            self._x, self._y, self._w, self._h = convertToAbsoluteValues(
                 imgSize, (x, y, w, h)
             )
             self._width_img = imgSize[0]
@@ -121,7 +121,7 @@ class BoundingBox:
 
         if (
             det1.getClassId() == det2.getClassId()
-            and det1.classConfidence == det2.classConfidenc()
+            and det1.getConfidence() == det2.getConfidence()
             and det1BB[0] == det2BB[0]
             and det1BB[1] == det2BB[1]
             and det1BB[2] == det2BB[2]

--- a/exercises/object_detection/benchmarking/BoundingBoxes.py
+++ b/exercises/object_detection/benchmarking/BoundingBoxes.py
@@ -12,7 +12,7 @@ class BoundingBoxes:
     def removeBoundingBox(self, _boundingBox):
         for d in self._boundingBoxes:
             if BoundingBox.compare(d, _boundingBox):
-                del self._boundingBoxes[d]
+                self._boundingBoxes.remove(d)
                 return
 
     def removeAllBoundingBoxes(self):

--- a/exercises/object_detection/benchmarking/Evaluator.py
+++ b/exercises/object_detection/benchmarking/Evaluator.py
@@ -139,7 +139,7 @@ class Evaluator:
         # Each resut represents a class
         for result in results:
             if result is None:
-                raise IOError("Error: Class %d could not be found." % classId)
+                raise IOError("Error: Class could not be found.")
 
             classId = result["class"]
             precision = result["precision"]

--- a/exercises/object_detection/benchmarking/benchmark.py
+++ b/exercises/object_detection/benchmarking/benchmark.py
@@ -1,4 +1,3 @@
-from os import path
 from BoundingBox import BoundingBox
 from BoundingBoxes import BoundingBoxes
 from utils import *

--- a/exercises/object_detection/benchmarking/utils.py
+++ b/exercises/object_detection/benchmarking/utils.py
@@ -91,9 +91,9 @@ def add_bb_into_image(image, bb, color=(255, 0, 0), thickness=2, label=None):
     # Add label
     if label is not None:
         # Get size of the text box
-        (tw, th) = cv2.getTextSize(label, font, fontScale, fontThickness)[0]
+        tw, th = cv2.getTextSize(label, font, fontScale, fontThickness)[0]
         # Top-left coord of the textbox
-        (xin_bb, yin_bb) = (x1 + thickness, y1 - th + int(12.5 * fontScale))
+        xin_bb, yin_bb = (x1 + thickness, y1 - th + int(12.5 * fontScale))
         # Checking position of the text top-left (outside or inside the bb)
         if yin_bb - th <= 0:  # if outside the image
             yin_bb = y1 + th  # put it inside the bb


### PR DESCRIPTION
## Description
Fixed four bugs in the object detection benchmarking utilities, all in files untouched since the initial exercise migration (596eafda).

## Changes

### benchmark.py
- Remove unused `from os import path` import

### BoundingBox.py
- Fix `compare()`: `det1.classConfidence` (direct private attr access) and `det2.classConfidenc()` (typo + wrong access) → `det1.getConfidence()` and `det2.getConfidence()`

### BoundingBoxes.py
- Fix `removeBoundingBox()`: `del self._boundingBoxes[d]` raises `TypeError` since `d` is a `BoundingBox` object, not an index → `self._boundingBoxes.remove(d)`

### Evaluator.py
- Fix `PlotPrecisionRecallCurve()`: `classId` referenced in error message before it is assigned in the loop body → removed `classId` from the error message

## Testing
- Ran `black` on all 5 files — passes cleanly