### PR TITLE
fix(file_access): fix read_binary in FAL_RA calling wrong super method and incorrect return type

### DIFF
--- a/academy/file_access.py
+++ b/academy/file_access.py
@@ -299,8 +299,8 @@ class FAL_RA(FAL):
         except Exception:
             raise BinaryNotSupported(path)
 
-    def read_binary(self, path: str) -> str:
-        super().read(path)
+    def read_binary(self, path: str) -> bytes:
+        super().read_binary(path)
 
         with open(path, "rb") as f:
             return f.read()


### PR DESCRIPTION
## Description
Fixed two related issues in `FAL_RA.read_binary()` in `academy/file_access.py`.

## Changes

### Wrong super() call
`FAL_RA.read_binary()` was calling `super().read(path)` instead of `super().read_binary(path)`. Both parent methods perform the same path validation, but calling the wrong one is semantically incorrect and misleading — `read_binary` should delegate validation to its own abstract counterpart.

### Incorrect return type annotation
The return type was annotated as `-> str`, but `open(path, "rb")` returns `bytes`, not `str`. Fixed to `-> bytes`.

## Testing
- `black` passes with no changes needed