### PR TITLE
docs(autoparking): add docstrings to HAL.py for 3D LiDAR universe

### DIFF
--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -68,19 +68,7 @@ def getPose3d():
 
 
 def getFrontLaserData():
-    """
-    Returns laser scan data from the front laser sensor.
-
-    NOTE: This belongs to the old 3-laser universe.
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
-
-    Returns:
-        LaserData: Object with attributes:
-            - values (list[float]): Distance measurements in meters
-            - minAngle (float): Start angle of scan in radians
-            - maxAngle (float): End angle of scan in radians
-            - timeStamp (float): Timestamp of the scan
-    """
+    
     laser = laser_front_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -90,19 +78,7 @@ def getFrontLaserData():
 
 
 def getRightLaserData():
-    """
-    Returns laser scan data from the right-side laser sensor.
-
-    NOTE: This belongs to the old 3-laser universe.
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
-
-    Returns:
-        LaserData: Object with attributes:
-            - values (list[float]): Distance measurements in meters
-            - minAngle (float): Start angle of scan in radians
-            - maxAngle (float): End angle of scan in radians
-            - timeStamp (float): Timestamp of the scan
-    """
+    
     laser = laser_right_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -112,19 +88,7 @@ def getRightLaserData():
 
 
 def getBackLaserData():
-    """
-    Returns laser scan data from the rear laser sensor.
-
-    NOTE: This belongs to the old 3-laser universe.
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
-
-    Returns:
-        LaserData: Object with attributes:
-            - values (list[float]): Distance measurements in meters
-            - minAngle (float): Start angle of scan in radians
-            - maxAngle (float): End angle of scan in radians
-            - timeStamp (float): Timestamp of the scan
-    """
+    
     laser = laser_back_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -134,30 +98,7 @@ def getBackLaserData():
 
 
 def getLidarData():
-    """
-    Returns 3D LiDAR point cloud data from the Prius autoparking vehicle.
-    This is the primary sensor for the NEW 3D LiDAR universe.
-    Subscribes to /prius_autoparking/pc2 (sensor_msgs/PointCloud2).
-
-    Use this function instead of the laser functions (getFrontLaserData,
-    getRightLaserData, getBackLaserData) when working in the 3D LiDAR universe.
-
-    Returns:
-        LidarData: Object with the following attributes:
-            - points (list[tuple]): List of (x, y, z) tuples in meters
-            - intensities (list[float]): Intensity values per point
-                                        (empty if not available)
-            - timeStamp (float): Timestamp in seconds
-            - min_range (float): Minimum sensor range in meters (default: 0.1)
-            - max_range (float): Maximum sensor range in meters (default: 15.0)
-            - field_of_view (tuple): (horizontal, vertical) FOV in radians
-            - is_dense (bool): True if all points are finite (no NaN/Inf)
-
-    Example:
-        lidar = HAL.getLidarData()
-        for point in lidar.points:
-            x, y, z = point
-    """
+   
     lidar = lidar_node.getLidarData()
     timestamp = lidar.timeStamp
     while timestamp == 0.0:

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -69,7 +69,7 @@ def getPose3d():
 
 def getFrontLaserData():
     """
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+    Returns laser scan data from the front laser sensor.
 
     Returns:
         LaserData: Object with attributes:
@@ -78,15 +78,17 @@ def getFrontLaserData():
             - maxAngle (float): End angle of scan in radians
             - timeStamp (float): Timestamp of the scan
     """
-    
     laser = laser_front_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
+        laser = laser_front_node.getLaserData()
+        timestamp = laser.timeStamp
+    return laser
 
 
 def getRightLaserData():
     """
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+    Returns laser scan data from the right-side laser sensor.
 
     Returns:
         LaserData: Object with attributes:
@@ -95,15 +97,17 @@ def getRightLaserData():
             - maxAngle (float): End angle of scan in radians
             - timeStamp (float): Timestamp of the scan
     """
-    
     laser = laser_right_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
+        laser = laser_right_node.getLaserData()
+        timestamp = laser.timeStamp
+    return laser
 
 
 def getBackLaserData():
     """
-    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+    Returns laser scan data from the rear laser sensor.
 
     Returns:
         LaserData: Object with attributes:
@@ -112,16 +116,17 @@ def getBackLaserData():
             - maxAngle (float): End angle of scan in radians
             - timeStamp (float): Timestamp of the scan
     """
-    
     laser = laser_back_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
+        laser = laser_back_node.getLaserData()
+        timestamp = laser.timeStamp
+    return laser
 
 
 def getLidarData():
     """
-    Use this function instead of the laser functions (getFrontLaserData,
-    getRightLaserData, getBackLaserData) when working in the 3D LiDAR universe.
+    Returns 3D LiDAR point cloud data from the Prius autoparking vehicle.
 
     Returns:
         LidarData: Object with the following attributes:
@@ -139,7 +144,31 @@ def getLidarData():
         for point in lidar.points:
             x, y, z = point
     """
-   
     lidar = lidar_node.getLidarData()
     timestamp = lidar.timeStamp
     while timestamp == 0.0:
+        lidar = lidar_node.getLidarData()
+        timestamp = lidar.timeStamp
+    return lidar
+
+
+def setV(velocity):
+    """
+    Sets the linear velocity of the car.
+
+    Args:
+        velocity (float): Linear velocity in m/s.
+                         Positive = forward, Negative = backward
+    """
+    motor_node.sendV(float(velocity))
+
+
+def setW(velocity):
+    """
+    Sets the angular velocity of the car.
+
+    Args:
+        velocity (float): Angular velocity in rad/s.
+                         Positive = left turn, Negative = right turn
+    """
+    motor_node.sendW(float(velocity))

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -145,3 +145,44 @@ def getLidarData():
     Returns:
         LidarData: Object with the following attributes:
             - points (list[tuple]): List of (x, y, z) tuples in meters
+            - intensities (list[float]): Intensity values per point
+                                        (empty if not available)
+            - timeStamp (float): Timestamp in seconds
+            - min_range (float): Minimum sensor range in meters (default: 0.1)
+            - max_range (float): Maximum sensor range in meters (default: 15.0)
+            - field_of_view (tuple): (horizontal, vertical) FOV in radians
+            - is_dense (bool): True if all points are finite (no NaN/Inf)
+
+    Example:
+        lidar = HAL.getLidarData()
+        for point in lidar.points:
+            x, y, z = point
+    """
+    lidar = lidar_node.getLidarData()
+    timestamp = lidar.timeStamp
+    while timestamp == 0.0:
+        lidar = lidar_node.getLidarData()
+        timestamp = lidar.timeStamp
+    return lidar
+
+
+def setV(velocity):
+    """
+    Sets the linear velocity of the car.
+
+    Args:
+        velocity (float): Linear velocity in m/s.
+                         Positive = forward, Negative = backward
+    """
+    motor_node.sendV(float(velocity))
+
+
+def setW(velocity):
+    """
+    Sets the angular velocity of the car.
+
+    Args:
+        velocity (float): Angular velocity in rad/s.
+                         Positive = left turn, Negative = right turn
+    """
+    motor_node.sendW(float(velocity))

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -2,7 +2,6 @@ import rclpy
 import threading
 import time
 import sys
-
 from hal_interfaces.general.motors import MotorsNode
 from hal_interfaces.general.odometry import OdometryNode
 from hal_interfaces.general.laser import LaserNode
@@ -13,17 +12,15 @@ IMG_WIDTH = 320
 IMG_HEIGHT = 240
 freq = 30.0
 
-
 # Mutes exceptions
 def custom_thread_excepthook(args):
     if "spin" in args.thread.name:
         return
     sys.__excepthook__(args.exc_type, args.exc_value, args.exc_traceback)
 
-
 threading.excepthook = custom_thread_excepthook
-# ROS2 init
 
+# ROS2 init
 print("HAL initializing", flush=True)
 if not rclpy.ok():
     rclpy.init(args=None)
@@ -44,7 +41,6 @@ executor.add_node(laser_right_node)
 executor.add_node(laser_back_node)
 executor.add_node(lidar_node)
 
-
 def __auto_spin() -> None:
     while rclpy.ok():
         try:
@@ -53,16 +49,38 @@ def __auto_spin() -> None:
             pass
         time.sleep(1 / freq)
 
-
 executor_thread = threading.Thread(target=__auto_spin, daemon=True)
 executor_thread.start()
 
 
 def getPose3d():
+    """
+    Returns the current pose of the car in 3D space.
+
+    Returns:
+        Pose3d: Object with the following attributes:
+            - x (float): X position in meters
+            - y (float): Y position in meters
+            - z (float): Z position in meters
+            - yaw (float): Rotation around Z axis in radians
+    """
     return odometry_node.getPose3d()
 
 
 def getFrontLaserData():
+    """
+    Returns laser scan data from the front laser sensor.
+
+    NOTE: This belongs to the old 3-laser universe.
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_front_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -72,6 +90,19 @@ def getFrontLaserData():
 
 
 def getRightLaserData():
+    """
+    Returns laser scan data from the right-side laser sensor.
+
+    NOTE: This belongs to the old 3-laser universe.
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_right_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -81,6 +112,19 @@ def getRightLaserData():
 
 
 def getBackLaserData():
+    """
+    Returns laser scan data from the rear laser sensor.
+
+    NOTE: This belongs to the old 3-laser universe.
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_back_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -90,17 +134,14 @@ def getBackLaserData():
 
 
 def getLidarData():
-    lidar = lidar_node.getLidarData()
-    timestamp = lidar.timeStamp
-    while timestamp == 0.0:
-        lidar = lidar_node.getLidarData()
-        timestamp = lidar.timeStamp
-    return lidar
+    """
+    Returns 3D LiDAR point cloud data from the Prius autoparking vehicle.
+    This is the primary sensor for the NEW 3D LiDAR universe.
+    Subscribes to /prius_autoparking/pc2 (sensor_msgs/PointCloud2).
 
+    Use this function instead of the laser functions (getFrontLaserData,
+    getRightLaserData, getBackLaserData) when working in the 3D LiDAR universe.
 
-def setV(velocity):
-    motor_node.sendV(float(velocity))
-
-
-def setW(velocity):
-    motor_node.sendW(float(velocity))
+    Returns:
+        LidarData: Object with the following attributes:
+            - points (list[tuple]): List of (x, y, z) tuples in meters

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -68,62 +68,78 @@ def getPose3d():
 
 
 def getFrontLaserData():
+    """
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     
     laser = laser_front_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
-        laser = laser_front_node.getLaserData()
-        timestamp = laser.timeStamp
-    return laser
 
 
 def getRightLaserData():
+    """
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     
     laser = laser_right_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
-        laser = laser_right_node.getLaserData()
-        timestamp = laser.timeStamp
-    return laser
 
 
 def getBackLaserData():
+    """
+    If you are using the new 3D LiDAR universe, use getLidarData() instead.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     
     laser = laser_back_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
-        laser = laser_back_node.getLaserData()
-        timestamp = laser.timeStamp
-    return laser
 
 
 def getLidarData():
+    """
+    Use this function instead of the laser functions (getFrontLaserData,
+    getRightLaserData, getBackLaserData) when working in the 3D LiDAR universe.
+
+    Returns:
+        LidarData: Object with the following attributes:
+            - points (list[tuple]): List of (x, y, z) tuples in meters
+            - intensities (list[float]): Intensity values per point
+                                        (empty if not available)
+            - timeStamp (float): Timestamp in seconds
+            - min_range (float): Minimum sensor range in meters (default: 0.1)
+            - max_range (float): Maximum sensor range in meters (default: 15.0)
+            - field_of_view (tuple): (horizontal, vertical) FOV in radians
+            - is_dense (bool): True if all points are finite (no NaN/Inf)
+
+    Example:
+        lidar = HAL.getLidarData()
+        for point in lidar.points:
+            x, y, z = point
+    """
    
     lidar = lidar_node.getLidarData()
     timestamp = lidar.timeStamp
     while timestamp == 0.0:
-        lidar = lidar_node.getLidarData()
-        timestamp = lidar.timeStamp
-    return lidar
-
-
-def setV(velocity):
-    """
-    Sets the linear velocity of the car.
-
-    Args:
-        velocity (float): Linear velocity in m/s.
-                         Positive = forward, Negative = backward
-    """
-    motor_node.sendV(float(velocity))
-
-
-def setW(velocity):
-    """
-    Sets the angular velocity of the car.
-
-    Args:
-        velocity (float): Angular velocity in rad/s.
-                         Positive = left turn, Negative = right turn
-    """
-    motor_node.sendW(float(velocity))


### PR DESCRIPTION
While going through the autoparking exercise I noticed that none of the 
HAL functions had any docstrings, which makes it hard to understand what 
each function returns, especially getLidarData() since the exercise recently 
shifted to a 3D LiDAR universe but the docs still don't reflect that.

Added docstrings to all HAL functions. The main focus was getLidarData() — 
documented the return type correctly (points are (x, y, z) tuples, not objects), 
and added a note clarifying that the three laser functions belong to the old 
universe and getLidarData() should be used in the new one.
<img width="1798" height="1301" alt="Screenshot 2026-04-05 174231" src="https://github.com/user-attachments/assets/9f882469-9e93-49e0-a19b-695dea34ac3f" />


Related to #3468