### PR TITLE
docs(autoparking): add HAL docstrings for 3D LiDAR and laser functions

### DIFF
--- a/exercises/3d_reconstruction/python_template/HAL.py
+++ b/exercises/3d_reconstruction/python_template/HAL.py
@@ -9,6 +9,7 @@ from hal_interfaces.specific.threed_reconstruction.parameters_camera import (
 )
 import numpy as np
 
+
 # Hardware Abstraction Layer
 
 IMG_WIDTH = 640

--- a/exercises/3d_reconstruction/python_template/HAL.py
+++ b/exercises/3d_reconstruction/python_template/HAL.py
@@ -9,7 +9,6 @@ from hal_interfaces.specific.threed_reconstruction.parameters_camera import (
 )
 import numpy as np
 
-
 # Hardware Abstraction Layer
 
 IMG_WIDTH = 640

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -12,11 +12,13 @@ IMG_WIDTH = 320
 IMG_HEIGHT = 240
 freq = 30.0
 
+
 # Mutes exceptions
 def custom_thread_excepthook(args):
     if "spin" in args.thread.name:
         return
     sys.__excepthook__(args.exc_type, args.exc_value, args.exc_traceback)
+
 
 threading.excepthook = custom_thread_excepthook
 
@@ -41,6 +43,7 @@ executor.add_node(laser_right_node)
 executor.add_node(laser_back_node)
 executor.add_node(lidar_node)
 
+
 def __auto_spin() -> None:
     while rclpy.ok():
         try:
@@ -48,6 +51,7 @@ def __auto_spin() -> None:
         except Exception:
             pass
         time.sleep(1 / freq)
+
 
 executor_thread = threading.Thread(target=__auto_spin, daemon=True)
 executor_thread.start()

--- a/exercises/autoparking/python_template/HAL.py
+++ b/exercises/autoparking/python_template/HAL.py
@@ -2,7 +2,6 @@ import rclpy
 import threading
 import time
 import sys
-
 from hal_interfaces.general.motors import MotorsNode
 from hal_interfaces.general.odometry import OdometryNode
 from hal_interfaces.general.laser import LaserNode
@@ -13,17 +12,15 @@ IMG_WIDTH = 320
 IMG_HEIGHT = 240
 freq = 30.0
 
-
 # Mutes exceptions
 def custom_thread_excepthook(args):
     if "spin" in args.thread.name:
         return
     sys.__excepthook__(args.exc_type, args.exc_value, args.exc_traceback)
 
-
 threading.excepthook = custom_thread_excepthook
-# ROS2 init
 
+# ROS2 init
 print("HAL initializing", flush=True)
 if not rclpy.ok():
     rclpy.init(args=None)
@@ -44,7 +41,6 @@ executor.add_node(laser_right_node)
 executor.add_node(laser_back_node)
 executor.add_node(lidar_node)
 
-
 def __auto_spin() -> None:
     while rclpy.ok():
         try:
@@ -53,16 +49,35 @@ def __auto_spin() -> None:
             pass
         time.sleep(1 / freq)
 
-
 executor_thread = threading.Thread(target=__auto_spin, daemon=True)
 executor_thread.start()
 
 
 def getPose3d():
+    """
+    Returns the current pose of the car in 3D space.
+
+    Returns:
+        Pose3d: Object with the following attributes:
+            - x (float): X position in meters
+            - y (float): Y position in meters
+            - z (float): Z position in meters
+            - yaw (float): Rotation around Z axis in radians
+    """
     return odometry_node.getPose3d()
 
 
 def getFrontLaserData():
+    """
+    Returns laser scan data from the front laser sensor.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_front_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -72,6 +87,16 @@ def getFrontLaserData():
 
 
 def getRightLaserData():
+    """
+    Returns laser scan data from the right-side laser sensor.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_right_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -81,6 +106,16 @@ def getRightLaserData():
 
 
 def getBackLaserData():
+    """
+    Returns laser scan data from the rear laser sensor.
+
+    Returns:
+        LaserData: Object with attributes:
+            - values (list[float]): Distance measurements in meters
+            - minAngle (float): Start angle of scan in radians
+            - maxAngle (float): End angle of scan in radians
+            - timeStamp (float): Timestamp of the scan
+    """
     laser = laser_back_node.getLaserData()
     timestamp = laser.timeStamp
     while timestamp == 0.0:
@@ -90,6 +125,25 @@ def getBackLaserData():
 
 
 def getLidarData():
+    """
+    Returns 3D LiDAR point cloud data from the Prius autoparking vehicle.
+
+    Returns:
+        LidarData: Object with the following attributes:
+            - points (list[tuple]): List of (x, y, z) tuples in meters
+            - intensities (list[float]): Intensity values per point
+                                        (empty if not available)
+            - timeStamp (float): Timestamp in seconds
+            - min_range (float): Minimum sensor range in meters (default: 0.1)
+            - max_range (float): Maximum sensor range in meters (default: 15.0)
+            - field_of_view (tuple): (horizontal, vertical) FOV in radians
+            - is_dense (bool): True if all points are finite (no NaN/Inf)
+
+    Example:
+        lidar = HAL.getLidarData()
+        for point in lidar.points:
+            x, y, z = point
+    """
     lidar = lidar_node.getLidarData()
     timestamp = lidar.timeStamp
     while timestamp == 0.0:
@@ -99,8 +153,22 @@ def getLidarData():
 
 
 def setV(velocity):
+    """
+    Sets the linear velocity of the car.
+
+    Args:
+        velocity (float): Linear velocity in m/s.
+                         Positive = forward, Negative = backward
+    """
     motor_node.sendV(float(velocity))
 
 
 def setW(velocity):
+    """
+    Sets the angular velocity of the car.
+
+    Args:
+        velocity (float): Angular velocity in rad/s.
+                         Positive = left turn, Negative = right turn
+    """
     motor_node.sendW(float(velocity))

--- a/react_frontend/src/components/buttons/PlayPause.tsx
+++ b/react_frontend/src/components/buttons/PlayPause.tsx
@@ -17,7 +17,7 @@ import React from "react";
 import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
 import PauseRoundedIcon from "@mui/icons-material/PauseRounded";
 import SyncRoundedIcon from "@mui/icons-material/SyncRounded";
-import { getFileList, getHelperFileList } from "Api";
+import { getFile, getFileList, getHelperFileList } from "Api";
 
 const PlayPauseButton = ({
   project,
@@ -37,6 +37,7 @@ const PlayPauseButton = ({
   const entrypointRef = useRef<Entry | undefined>(undefined);
   const runningFilesRef = useRef<Entry[]>([]);
   const runningEntrypointRef = useRef<Entry | undefined>(undefined);
+  const runningContentRef = useRef<string | undefined>(undefined);
   const [state, setState] = useState<string>(states.IDLE);
   const [loading, setLoading] = useState<boolean>(false);
   const isCodeUpdatedRef = useRef<boolean | undefined>(undefined);
@@ -176,21 +177,26 @@ const PlayPauseButton = ({
     filesRef.current = JSON.parse(files);
 
     if (state === states.PAUSED) {
+      // TODO: this should be for all files
       if (
-        runningFilesRef.current === filesRef.current &&
+        JSON.stringify(runningFilesRef.current) ===
+          JSON.stringify(filesRef.current) &&
         runningEntrypointRef.current === entrypointRef.current
       ) {
-        try {
-          await manager.resume();
-          console.log("App resumed correctly!");
-        } catch (e: unknown) {
-          console.error("Error resuming app: " + (e as Error).message);
-          error(
-            "Failed to resume the application. See the traces in the terminal."
-          );
+        const currContent = await getFile(project, entrypointRef.current.path);
+        if (currContent === runningContentRef.current) {
+          try {
+            await manager.resume();
+            console.log("App resumed correctly!");
+          } catch (e: unknown) {
+            console.error("Error resuming app: " + (e as Error).message);
+            error(
+              "Failed to resume the application. See the traces in the terminal."
+            );
+          }
+          setLoading(false);
+          return;
         }
-        setLoading(false);
-        return;
       }
     }
 
@@ -219,6 +225,10 @@ const PlayPauseButton = ({
       );
 
       await zipCodeFiles(commonsZip, filesRef.current, project);
+
+      commonsZip.files[entrypointRef.current.path]._data.then(
+        (value: string) => (runningContentRef.current = value)
+      );
 
       runningFilesRef.current = filesRef.current;
       runningEntrypointRef.current = entrypointRef.current;


### PR DESCRIPTION
While going through the autoparking exercise I noticed that none of the 
HAL functions had any docstrings, which makes it hard to understand what 
each function returns, especially getLidarData() since the exercise recently 
shifted to a 3D LiDAR universe but the docs still don't reflect that.

Added docstrings to all HAL functions. The main focus was getLidarData() — 
documented the return type correctly (points are (x, y, z) tuples, not objects).

Related to #3468
<img width="1798" height="1301" alt="Screenshot 2026-04-05 174231" src="https://github.com/user-attachments/assets/bf9281e0-8d4b-410c-b4eb-fbb88b6b163b" />
