### PR TITLE
tests: add tests for get_helper_file and get_helper_file_list views

### DIFF
--- a/academy/tests.py
+++ b/academy/tests.py
@@ -382,6 +382,91 @@ class FileManagementViewTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class GetHelperFileViewTests(TestCase):
+    """Tests for get_helper_file and get_helper_file_list endpoints."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        os.environ["FILESERVER_PATH"] = self.tmp
+        self.fal = FAL_RA()
+        exercise = Exercise.objects.create(
+            exercise_id="helper_test_ex",
+            name="Helper Test Exercise",
+            description="Test",
+            url="helper_test_ex",
+        )
+        project_path = self.fal.create(exercise.exercise_id)
+        helper_dir = os.path.join(project_path, "code")
+        os.makedirs(helper_dir, exist_ok=True)
+        with open(os.path.join(helper_dir, "helper.py"), "w") as f:
+            f.write("# helper content")
+        with open(os.path.join(helper_dir, "model.onnx"), "wb") as f:
+            f.write(b"\x00\x01\x02\x03")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_get_helper_file_missing_project_returns_400(self):
+        response = self.client.get(
+            "/academy/get_helper_file/",
+            {"language": "python", "filename": "helper.py"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_helper_file_missing_filename_returns_text_file(self):
+        response = self.client.get(
+            "/academy/get_helper_file/",
+            {
+                "project": "helper_test_ex",
+                "language": "python",
+                "filename": "helper.py",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("content", response.json())
+
+    def test_get_helper_file_binary_returns_base64(self):
+        response = self.client.get(
+            "/academy/get_helper_file/",
+            {
+                "project": "helper_test_ex",
+                "language": "python",
+                "filename": "model.onnx",
+                "binary": "true",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.json()["content"]
+        # Must be valid base64
+        decoded = base64.b64decode(content)
+        self.assertEqual(decoded, b"\x00\x01\x02\x03")
+
+    def test_get_helper_file_text_without_binary_flag(self):
+        response = self.client.get(
+            "/academy/get_helper_file/",
+            {
+                "project": "helper_test_ex",
+                "language": "python",
+                "filename": "helper.py",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["content"], "# helper content")
+
+    def test_get_helper_file_list_missing_project_returns_400(self):
+        response = self.client.get(
+            "/academy/get_helper_file_list/",
+            {"language": "python"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_helper_file_list_valid_returns_200(self):
+        response = self.client.get(
+            "/academy/get_helper_file_list/",
+            {"project": "helper_test_ex", "language": "python"},
+        )
+        self.assertEqual(response.status_code, 200)
+
 class TemplateTests(TestCase):
     """Tests for academy/templates.py select_template function."""
 

--- a/academy/tests.py
+++ b/academy/tests.py
@@ -467,6 +467,7 @@ class GetHelperFileViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+
 class TemplateTests(TestCase):
     """Tests for academy/templates.py select_template function."""
 


### PR DESCRIPTION
I've added 6 tests covering both endpoints added in recently merged PR #3751

Tests added in `GetHelperFileViewTests`:
- Missing `project` param returns 400 for both endpoints
- Text file retrieval returns correct content
- Binary file retrieval with `binary=true` returns valid base64
- Text file retrieval without binary flag returns raw content  
- Valid project returns 200 for file list endpoint

