### PR TITLE
fix(views): check helpers before writing file in create_file

### DIFF
--- a/academy/views.py
+++ b/academy/views.py
@@ -234,10 +234,10 @@ def create_file(fal, request):
     if template is not None:
         content = select_template(template)
 
-    fal.create(file_path, content)
-
     if exists_in_helpers(fal, create_path, project_id):
         raise ResourceAlreadyExistsHelpers(create_path)
+
+    fal.create(file_path, content)
 
     return Response({"success": True})
 


### PR DESCRIPTION
`create_file` was calling `fal.create()` before `exists_in_helpers()`. If the file conflicted with a helper template, the 412 error was returned but the file was already written to disk.

Moved the helpers check before the create call, matching the order used in `create_folder`, `rename_file`, and `rename_folder`.

Closes #3760