### PR TITLE
fix(models): remove extra quotes in db_column breaking test DB creation

### DIFF
--- a/academy/models.py
+++ b/academy/models.py
@@ -110,10 +110,10 @@ class Universe(models.Model):
 
     name = models.CharField(max_length=100, blank=False, unique=True)
     world = models.OneToOneField(
-        World, default=None, on_delete=models.CASCADE, db_column='"world_id"'
+        World, default=None, on_delete=models.CASCADE, db_column="world_id"
     )
     robot = models.OneToOneField(
-        Robot, default=None, on_delete=models.CASCADE, db_column='"robot_id"'
+        Robot, default=None, on_delete=models.CASCADE, db_column="robot_id"
     )
 
     def __str__(self):


### PR DESCRIPTION
The db_column values on lines 113 and 116 in models.py had extra double quotes (`'"world_id"'` instead of `'world_id'`). This caused a PostgreSQL syntax error when Django tried to create the test database, blocking `manage.py test` entirely.

The production database columns are `world_id` and `robot_id` without quotes, so the extra quotes were unnecessary.

Closes #3762