### PR TITLE
RADI performance monitor

### DIFF
--- a/scripts/radi_monitor/lib/analysis.py
+++ b/scripts/radi_monitor/lib/analysis.py
@@ -1,0 +1,203 @@
+"""
+analysis.py — Statistics computation and diagnosis for radi_monitor.
+
+Derives per-session and per-exercise summaries, process inventory, exercise event
+timeline, and an automatic diagnosis with actionable findings.
+"""
+
+from collections import defaultdict
+
+from .collector import CATEGORY_COLOR, categorize, detect_exercise, friendly_name
+
+
+def _dur(sec):
+    m, s = divmod(int(sec), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def get_exercise_events(samples, manual_events):
+    # Build events without mutating the sample dicts
+    events, prev = [], None
+    for s in samples:
+        if s.get("exercise_source") != "manual":
+            exc = detect_exercise(s.get("processes", []))
+        else:
+            exc = s.get("exercise")
+        label = exc or "idle"
+        if label != prev:
+            events.append((s["t"], label, "auto"))
+            prev = label
+
+    for ev in manual_events or []:
+        events.append((ev["t"], ev["name"], "manual"))
+    events.sort(key=lambda x: x[0])
+
+    deduped, prev_name = [], None
+    for t, name, src in events:
+        if name != prev_name:
+            deduped.append((t, name, src))
+            prev_name = name
+    return deduped
+
+
+def session_summary(samples, cpu_threads):
+    cpus = [s["container"]["cpu_pct"] for s in samples]
+    mems = [s["container"]["mem_mb"] for s in samples]
+    hcpu = [s["host"]["cpu_pct"] for s in samples]
+    gpus = [s["gpu"]["util_pct"] for s in samples if s.get("gpu")]
+    rtfs = [s["rtf"] for s in samples if s.get("rtf") is not None]
+    return {
+        "duration": samples[-1]["t"],
+        "n": len(samples),
+        "cpu_avg": round(sum(cpus) / len(cpus), 1),
+        "cpu_peak": round(max(cpus), 1),
+        "cpu_max_pct": cpu_threads * 100,
+        "mem_avg_gb": round(sum(mems) / len(mems) / 1024, 2),
+        "mem_peak_gb": round(max(mems) / 1024, 2),
+        "host_cpu_avg": round(sum(hcpu) / len(hcpu), 1),
+        "gpu_avg": round(sum(gpus) / len(gpus), 1) if gpus else None,
+        "gpu_peak": round(max(gpus), 1) if gpus else None,
+        "rtf_avg": round(sum(rtfs) / len(rtfs), 3) if rtfs else None,
+        "rtf_min": round(min(rtfs), 3) if rtfs else None,
+    }
+
+
+def per_exercise_stats(samples, exercise_events):
+    rows = []
+    for i, (t0, name, src) in enumerate(exercise_events):
+        t1 = exercise_events[i + 1][0] if i + 1 < len(exercise_events) else samples[-1]["t"]
+        w = [s for s in samples if t0 <= s["t"] <= t1]
+        if not w:
+            continue
+        cpus = [s["container"]["cpu_pct"] for s in w]
+        mems = [s["container"]["mem_mb"] for s in w]
+        gpus = [s["gpu"]["util_pct"] for s in w if s.get("gpu")]
+        rtfs = [s["rtf"] for s in w if s.get("rtf") is not None]
+        rows.append(
+            {
+                "name": name,
+                "source": src,
+                "duration": t1 - t0,
+                "cpu_avg": round(sum(cpus) / len(cpus), 1),
+                "cpu_peak": round(max(cpus), 1),
+                "ram_avg": round(sum(mems) / len(mems) / 1024, 2),
+                "gpu_avg": round(sum(gpus) / len(gpus), 1) if gpus else None,
+                "rtf_avg": round(sum(rtfs) / len(rtfs), 3) if rtfs else None,
+                "rtf_min": round(min(rtfs), 3) if rtfs else None,
+            }
+        )
+    rows.sort(key=lambda x: -x["cpu_avg"])
+    return rows
+
+
+def process_inventory(samples):
+    data = defaultdict(lambda: {"cpu": [], "mem": [], "seen": 0, "cmd": ""})
+    for s in samples:
+        seen = set()
+        for p in s.get("processes", []):
+            key = friendly_name(p)
+            if key in seen:
+                continue
+            seen.add(key)
+            data[key]["cpu"].append(p.get("cpu", 0))
+            data[key]["mem"].append(p.get("mem_mb", 0))
+            data[key]["seen"] += 1
+            data[key]["cmd"] = p.get("cmd", "")
+    total = len(samples)
+    out = []
+    for name, d in data.items():
+        n = len(d["cpu"])
+        out.append(
+            {
+                "name": name,
+                "cat": categorize({"name": name, "cmd": d["cmd"]}),
+                "avg_cpu": round(sum(d["cpu"]) / n, 1),
+                "peak_cpu": round(max(d["cpu"]), 1),
+                "avg_mem": round(sum(d["mem"]) / n, 1),
+                "pct_time": round(d["seen"] / total * 100),
+            }
+        )
+    out.sort(key=lambda x: -x["avg_cpu"])
+    return out[:15]
+
+
+def measurement_summary(samples, summary):
+    """Return a list of objective (metric, avg, peak, detail) rows — no interpretation."""
+    rows = []
+    max_pct = summary["cpu_max_pct"]
+    threads = max_pct // 100
+
+    rows.append(
+        (
+            "Container CPU",
+            f"{summary['cpu_avg']}%",
+            f"{summary['cpu_peak']}%",
+            f"max {max_pct}%  ({threads} logical cores)",
+        )
+    )
+
+    mems = [s["container"]["mem_mb"] for s in samples]
+    mem_change = (sum(mems[-5:]) / 5 - sum(mems[:5]) / 5) if len(mems) >= 10 else None
+    mem_detail = f"net change {mem_change:+.0f} MB" if mem_change is not None else "—"
+    rows.append(
+        (
+            "Container RAM",
+            f"{summary['mem_avg_gb']} GiB",
+            f"{summary['mem_peak_gb']} GiB",
+            mem_detail,
+        )
+    )
+
+    rtf_samples = [s for s in samples if s.get("rtf") is not None]
+    if summary.get("rtf_avg") is not None:
+        rows.append(
+            (
+                "Gazebo RTF",
+                f"{summary['rtf_avg']:.3f}",
+                f"min {summary['rtf_min']:.3f}",
+                f"{len(rtf_samples)} / {len(samples)} samples",
+            )
+        )
+    else:
+        rows.append(("Gazebo RTF", "—", "—", "no samples with active simulation"))
+
+    if summary.get("gpu_avg") is not None:
+        rows.append(
+            ("GPU utilization", f"{summary['gpu_avg']}%", f"{summary['gpu_peak']}%", "—")
+        )
+    else:
+        rows.append(("GPU utilization", "—", "—", "not detected on host"))
+
+    rows.append(("Host CPU", f"{summary['host_cpu_avg']}%", "—", "—"))
+
+    rx0 = samples[0]["container"].get("net_rx_mb", 0)
+    tx0 = samples[0]["container"].get("net_tx_mb", 0)
+    rx1 = samples[-1]["container"].get("net_rx_mb", 0)
+    tx1 = samples[-1]["container"].get("net_tx_mb", 0)
+    rows.append(
+        (
+            "Network I/O",
+            "—",
+            "—",
+            f"RX {max(0, rx1 - rx0):.1f} MB  ·  TX {max(0, tx1 - tx0):.1f} MB",
+        )
+    )
+
+    return rows
+
+
+def category_cpu_over_time(samples):
+    """Aggregate per-process CPU into category buckets for each sample.
+
+    Returns (times, series) where series is {category: [float, ...]} aligned to times.
+    """
+    categories = list(CATEGORY_COLOR.keys())
+    times = [s["t"] for s in samples]
+    series = {cat: [] for cat in categories}
+    for s in samples:
+        totals = {cat: 0.0 for cat in categories}
+        for p in s.get("processes", []):
+            totals[categorize(p)] += p.get("cpu", 0.0)
+        for cat in categories:
+            series[cat].append(totals[cat])
+    return times, series

--- a/scripts/radi_monitor/lib/charts.py
+++ b/scripts/radi_monitor/lib/charts.py
@@ -1,0 +1,340 @@
+"""
+charts.py — Matplotlib chart generation for radi_monitor.
+
+All public functions return a base64-encoded PNG string suitable for inline
+embedding in HTML (<img src="data:image/png;base64,...">).
+"""
+
+import base64
+import io
+import sys
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except ImportError:
+    sys.exit("matplotlib not found. Run: pip3 install matplotlib")
+
+from .analysis import category_cpu_over_time
+from .collector import CATEGORY_COLOR
+
+_EXC_PALETTE = [
+    "#1565c0",
+    "#2e7d32",
+    "#6a1b9a",
+    "#c62828",
+    "#00695c",
+    "#ad1457",
+    "#0277bd",
+    "#558b2f",
+    "#4e342e",
+    "#37474f",
+]
+
+_CHART_RC = {
+    "font.size": 11,
+    "axes.grid": True,
+    "grid.alpha": 0.35,
+    "figure.facecolor": "white",
+    "axes.facecolor": "#fafafa",
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+}
+
+
+def _chart_setup():
+    """Reset matplotlib state and apply project-wide rc params."""
+    plt.rcdefaults()
+    plt.rcParams.update(_CHART_RC)
+
+
+def _fig_to_b64(fig):
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=110, bbox_inches="tight", facecolor="white")
+    buf.seek(0)
+    b64 = base64.b64encode(buf.read()).decode()
+    plt.close(fig)
+    return b64
+
+
+def _add_exercise_bands(ax, exercise_events, times, ymax):
+    for i, (t0, name, *_) in enumerate(exercise_events):
+        t1 = exercise_events[i + 1][0] if i + 1 < len(exercise_events) else times[-1]
+        color = _EXC_PALETTE[i % len(_EXC_PALETTE)]
+        ax.axvspan(t0, t1, alpha=0.09, color=color, zorder=0)
+        if name != "idle":
+            label = name.replace("_harmonic", "").replace("_", " ")
+            ax.text(
+                (t0 + t1) / 2,
+                ymax * 0.98,
+                label,
+                ha="center",
+                va="top",
+                fontsize=8,
+                color=color,
+                fontweight="bold",
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor=color, alpha=0.85),
+            )
+
+
+def chart_cpu(samples, exercise_events, cpu_threads):
+    _chart_setup()
+    fig, ax = plt.subplots(figsize=(14, 4))
+
+    times = [s["t"] for s in samples]
+    cont_cpu = [s["container"]["cpu_pct"] for s in samples]
+    host_cpu = [s["host"]["cpu_pct"] for s in samples]
+    ymax = max(max(cont_cpu), max(host_cpu), 10) * 1.18
+
+    _add_exercise_bands(ax, exercise_events, times, ymax)
+    ax.plot(times, cont_cpu, color="#d32f2f", linewidth=2, label="Container CPU %", zorder=3)
+    ax.plot(
+        times,
+        host_cpu,
+        color="#555",
+        linewidth=1,
+        linestyle="--",
+        alpha=0.5,
+        label="Host CPU %",
+        zorder=2,
+    )
+    ax.fill_between(times, cont_cpu, alpha=0.07, color="#d32f2f")
+    ax.axhline(
+        y=cpu_threads * 100,
+        color="#d32f2f",
+        linewidth=0.8,
+        linestyle=":",
+        alpha=0.4,
+        label=f"Max ({cpu_threads * 100}%)",
+    )
+    ax.set_ylim(0, ymax)
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("CPU %")
+    ax.set_title("Container CPU over time", fontweight="bold", fontsize=13)
+    ax.legend(fontsize=9, loc="upper left")
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_rtf(samples, exercise_events):
+    rtf_pts = [(s["t"], s["rtf"]) for s in samples if s.get("rtf") is not None]
+    if not rtf_pts:
+        return None
+
+    _chart_setup()
+    fig, ax = plt.subplots(figsize=(14, 3.5))
+
+    times = [s["t"] for s in samples]
+    rt, rv = zip(*rtf_pts)
+
+    # Background zones: green >= 0.95, amber 0.80-0.95, red < 0.80
+    ax.axhspan(0.95, 1.15, alpha=0.06, color="#2e7d32", zorder=0)
+    ax.axhspan(0.80, 0.95, alpha=0.07, color="#f9a825", zorder=0)
+    ax.axhspan(0.00, 0.80, alpha=0.07, color="#d32f2f", zorder=0)
+
+    _add_exercise_bands(ax, exercise_events, times, 1.15)
+    ax.plot(rt, rv, color="#1565c0", linewidth=2, label="RTF", zorder=3)
+    ax.fill_between(rt, rv, alpha=0.10, color="#1565c0", zorder=2)
+    ax.axhline(
+        y=1.0, color="#2e7d32", linewidth=1, linestyle="--", alpha=0.6, label="Real-time (1.0)", zorder=4
+    )
+
+    ax.set_ylim(0, 1.15)
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Real-Time Factor")
+    ax.set_title(
+        "Gazebo RTF over time  (gaps = no active simulation)", fontweight="bold", fontsize=13
+    )
+    ax.legend(fontsize=9, loc="lower right")
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_process_bars(inventory):
+    _chart_setup()
+    plt.rcParams.update({"axes.spines.left": False})
+    top = [p for p in inventory if p["avg_cpu"] >= 0.3][:12]
+    if not top:
+        return None
+
+    labels = [p["name"][:48] for p in reversed(top)]
+    avgs = [p["avg_cpu"] for p in reversed(top)]
+    peaks = [p["peak_cpu"] for p in reversed(top)]
+    colors = [CATEGORY_COLOR.get(p["cat"], "#9e9e9e") for p in reversed(top)]
+
+    fig, ax = plt.subplots(figsize=(14, max(4, len(top) * 0.65)))
+    y = list(range(len(labels)))
+    ax.barh(y, peaks, color=colors, alpha=0.20, height=0.55)
+    bars = ax.barh(y, avgs, color=colors, alpha=0.88, height=0.55)
+    for bar, v, vp in zip(bars, avgs, peaks):
+        ax.text(
+            v + 0.5,
+            bar.get_y() + bar.get_height() / 2,
+            f"  avg {v:.0f}%  peak {vp:.0f}%",
+            va="center",
+            fontsize=8.5,
+            color="#333",
+        )
+    ax.set_yticks(y)
+    ax.set_yticklabels(labels)
+    ax.set_xlabel("CPU %")
+    ax.set_title(
+        "CPU per process  (solid bar = avg, light bar = peak)", fontweight="bold", fontsize=13
+    )
+    ax.grid(axis="x", alpha=0.35)
+    ax.set_axisbelow(True)
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_memory(samples, exercise_events):
+    _chart_setup()
+    fig, ax1 = plt.subplots(figsize=(14, 3.5))
+
+    times = [s["t"] for s in samples]
+    cont_mem = [s["container"]["mem_mb"] / 1024 for s in samples]
+    host_mem = [s["host"]["mem_used_gb"] for s in samples]
+
+    _add_exercise_bands(ax1, exercise_events, times, max(cont_mem) * 1.25)
+    ax2 = ax1.twinx()
+    (l1,) = ax1.plot(times, cont_mem, color="#e65100", linewidth=2, label="Container RAM (GiB)")
+    ax1.fill_between(times, cont_mem, alpha=0.08, color="#e65100")
+    (l2,) = ax2.plot(
+        times, host_mem, color="#555", linewidth=1, linestyle="--", alpha=0.5, label="Host RAM (GiB)"
+    )
+    ax1.set_ylim(0, max(cont_mem) * 1.25)
+    ax1.set_xlabel("Time (s)")
+    ax1.set_ylabel("Container RAM (GiB)", color="#e65100")
+    ax2.set_ylabel("Host RAM (GiB)", color="#555")
+    ax1.set_title("Memory usage over time", fontweight="bold", fontsize=13)
+    ax1.legend([l1, l2], [l1.get_label(), l2.get_label()], fontsize=9)
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_gpu(samples, exercise_events):
+    gpu_samples = [s for s in samples if s.get("gpu")]
+    if not gpu_samples:
+        return None
+
+    _chart_setup()
+    fig, (ax_util, ax_detail) = plt.subplots(1, 2, figsize=(14, 3))
+
+    times = [s["t"] for s in gpu_samples]
+    util = [s["gpu"]["util_pct"] for s in gpu_samples]
+
+    _add_exercise_bands(ax_util, exercise_events, times, max(util) * 1.2 or 10)
+    ax_util.plot(times, util, color="#6a1b9a", linewidth=2)
+    ax_util.fill_between(times, util, alpha=0.1, color="#6a1b9a")
+    ax_util.set_ylim(0, max(util) * 1.2 if max(util) > 0 else 10)
+    ax_util.set_xlabel("Time (s)")
+    ax_util.set_ylabel("GPU %")
+    ax_util.set_title("GPU utilization", fontweight="bold")
+
+    mem = [s["gpu"].get("mem_used_mb") or 0 for s in gpu_samples]
+    temp = [s["gpu"].get("temp_c") for s in gpu_samples]
+    if any(m > 0 for m in mem):
+        ax_detail.plot(times, mem, color="#0277bd", linewidth=2, label="VRAM (MB)")
+        ax_detail.set_ylabel("VRAM (MB)", color="#0277bd")
+    if any(t is not None for t in temp):
+        ax_t = ax_detail.twinx()
+        ax_t.plot(
+            times,
+            [t or 0 for t in temp],
+            color="#e65100",
+            linewidth=1.5,
+            linestyle="--",
+            label="Temp (°C)",
+        )
+        ax_t.set_ylabel("Temp (°C)", color="#e65100")
+    ax_detail.set_xlabel("Time (s)")
+    ax_detail.set_title("VRAM and temperature", fontweight="bold")
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_category_cpu(samples, exercise_events):
+    """Stacked area chart showing how total CPU is split across process categories."""
+    times, series = category_cpu_over_time(samples)
+
+    # Only include categories that are meaningfully active
+    active = {cat: vals for cat, vals in series.items() if max(vals, default=0) >= 1.0}
+    if not active:
+        return None
+
+    _chart_setup()
+    fig, ax = plt.subplots(figsize=(14, 4.5))
+
+    cats = list(active.keys())
+    vals = [active[c] for c in cats]
+    colors = [CATEGORY_COLOR.get(c, "#9e9e9e") for c in cats]
+
+    ax.stackplot(times, vals, labels=cats, colors=colors, alpha=0.82)
+
+    # Draw exercise transitions as vertical dashed lines on top of the stacked area
+    for i, (t0, name, *_) in enumerate(exercise_events):
+        if name != "idle":
+            color = _EXC_PALETTE[i % len(_EXC_PALETTE)]
+            ax.axvline(t0, color=color, linewidth=1.2, linestyle="--", alpha=0.7, zorder=5)
+            ymax = ax.get_ylim()[1] or 10
+            ax.text(
+                t0 + (times[-1] - times[0]) * 0.005,
+                ymax * 0.96,
+                name.replace("_harmonic", "").replace("_", " "),
+                fontsize=7.5,
+                color=color,
+                va="top",
+                bbox=dict(boxstyle="round,pad=0.15", facecolor="white", edgecolor=color, alpha=0.88),
+                zorder=6,
+            )
+
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("CPU %  (sum of per-process measurements)")
+    ax.set_title("CPU distribution by category over time", fontweight="bold", fontsize=13)
+    ax.legend(loc="upper left", fontsize=9, ncol=3, framealpha=0.92)
+    fig.tight_layout()
+    return _fig_to_b64(fig)
+
+
+def chart_network(samples):
+    """Line chart of container network throughput (MB/s) derived from docker stats deltas."""
+    if len(samples) < 2:
+        return None
+
+    rx_cum = [s["container"].get("net_rx_mb", 0) for s in samples]
+    tx_cum = [s["container"].get("net_tx_mb", 0) for s in samples]
+    times = [s["t"] for s in samples]
+
+    # Session totals (cumulative values from container start, so we take the delta)
+    total_rx = max(0.0, rx_cum[-1] - rx_cum[0])
+    total_tx = max(0.0, tx_cum[-1] - tx_cum[0])
+    if total_rx < 0.5 and total_tx < 0.5:
+        return None  # No meaningful network activity
+
+    # Per-interval throughput in MB/s
+    dt = [max(times[i] - times[i - 1], 0.1) for i in range(1, len(times))]
+    rx_bps = [max(0.0, rx_cum[i] - rx_cum[i - 1]) / dt[i - 1] for i in range(1, len(rx_cum))]
+    tx_bps = [max(0.0, tx_cum[i] - tx_cum[i - 1]) / dt[i - 1] for i in range(1, len(tx_cum))]
+    t_mid = times[1:]
+
+    _chart_setup()
+    fig, ax = plt.subplots(figsize=(14, 3))
+    ax.plot(t_mid, rx_bps, color="#1565c0", linewidth=1.8, label=f"RX  (total {total_rx:.1f} MB)")
+    ax.plot(
+        t_mid,
+        tx_bps,
+        color="#e65100",
+        linewidth=1.8,
+        linestyle="--",
+        label=f"TX  (total {total_tx:.1f} MB)",
+    )
+    ax.fill_between(t_mid, rx_bps, alpha=0.10, color="#1565c0")
+    ax.fill_between(t_mid, tx_bps, alpha=0.10, color="#e65100")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("MB/s")
+    ax.set_title("Container network throughput", fontweight="bold", fontsize=13)
+    ax.legend(fontsize=9)
+    fig.tight_layout()
+    return _fig_to_b64(fig)

--- a/scripts/radi_monitor/lib/collector.py
+++ b/scripts/radi_monitor/lib/collector.py
@@ -1,0 +1,359 @@
+"""
+collector.py — Docker container and host data collection for radi_monitor.
+
+Provides functions to query container CPU/RAM (docker stats), per-process metrics
+(psutil inside the container via docker exec), Gazebo RTF (/stats topic), GPU stats
+(nvidia-smi or /sys/class/drm), host CPU/RAM, and exercise auto-detection from
+process cmdlines.
+"""
+
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+
+try:
+    import psutil
+except ImportError:
+    sys.exit("psutil not found. Run: pip3 install psutil")
+
+RADI_IMAGE = "robotics-backend"
+
+CATEGORY_COLOR = {
+    "Gazebo Server": "#d32f2f",
+    "Gazebo Client": "#f57c00",
+    "RAM Manager": "#1565c0",
+    "Django": "#2e7d32",
+    "ROS2 Bridges": "#f9a825",
+    "ROS2 Nodes": "#e65100",
+    "VNC": "#6a1b9a",
+    "User code": "#37474f",
+    "Other": "#9e9e9e",
+}
+
+# Runs inside the container via docker exec; two-pass CPU measurement is required
+# because psutil.cpu_percent(interval=None) needs a prior call to initialise counters.
+_PSUTIL_SCRIPT = """
+import psutil, json, time
+procs = {}
+for p in psutil.process_iter(['pid', 'name', 'cmdline']):
+    try:
+        procs[p.pid] = p
+        p.cpu_percent(interval=None)
+    except Exception:
+        pass
+time.sleep(0.5)
+out = []
+for pid, p in procs.items():
+    try:
+        out.append({'pid': pid, 'name': p.name(),
+                    'cpu': round(p.cpu_percent(interval=None), 2),
+                    'mem_mb': round(p.memory_info().rss / 1048576, 2),
+                    'cmd': ' '.join(p.cmdline()[:6]) if p.cmdline() else p.name()})
+    except Exception:
+        pass
+out.sort(key=lambda x: -x['cpu'])
+print(json.dumps(out))
+"""
+
+
+def collect_system_info():
+    info = {}
+    try:
+        out = subprocess.check_output(["lsb_release", "-d"], text=True, timeout=3)
+        info["os"] = out.split(":", 1)[1].strip()
+    except Exception:
+        info["os"] = platform.platform()
+    info["kernel"] = platform.release()
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if "model name" in line:
+                    info["cpu"] = line.split(":", 1)[1].strip()
+                    break
+    except Exception:
+        info["cpu"] = platform.processor() or "unknown"
+    info["cpu_cores"] = psutil.cpu_count(logical=False) or 1
+    info["cpu_threads"] = psutil.cpu_count(logical=True) or 1
+    info["ram_gb"] = round(psutil.virtual_memory().total / 1024**3, 1)
+    gpus = []
+    try:
+        out = subprocess.check_output(["lspci"], text=True, timeout=5)
+        for line in out.splitlines():
+            if re.search(r"VGA|3D controller", line, re.I):
+                gpus.append(line.split(":", 2)[-1].strip())
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+        nvidia = [line.strip() for line in out.strip().splitlines() if line.strip()]
+        if nvidia:
+            gpus = nvidia
+    except Exception:
+        pass
+    info["gpus"] = gpus or ["not detected"]
+
+    # Full nvidia-smi table for the report (None if no NVIDIA GPU)
+    try:
+        info["nvidia_smi"] = subprocess.check_output(
+            ["nvidia-smi"], text=True, stderr=subprocess.DEVNULL, timeout=5
+        ).strip()
+    except Exception:
+        info["nvidia_smi"] = None
+
+    return info
+
+
+def check_container_gpu(cid):
+    """Run nvidia-smi inside the container. Returns a summary string or None."""
+    try:
+        out = subprocess.check_output(
+            [
+                "docker",
+                "exec",
+                cid,
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,driver_version",
+                "--format=csv,noheader",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        if out.strip():
+            return out.strip()
+    except Exception:
+        pass
+    return None
+
+
+def categorize(p):
+    name, cmd = p.get("name", ""), p.get("cmd", "")
+    # Gazebo Harmonic runs as 'ruby' with 'gz sim' in the cmdline
+    if name == "ruby" or "gz sim" in cmd:
+        return "Gazebo Client" if ("-g" in cmd or "--gui" in cmd) else "Gazebo Server"
+    c = (name + " " + cmd).lower()
+    if "gzserver" in c:
+        return "Gazebo Server"
+    if "gzclient" in c:
+        return "Gazebo Client"
+    if "manager.py" in c or "ram_entrypoint" in c:
+        return "RAM Manager"
+    if "manage.py" in c or "runserver" in c:
+        return "Django"
+    if "bridge" in c or "gz-transport" in c:
+        return "ROS2 Bridges"
+    if "/opt/ros" in c or "ros2" in c or "_node" in c or "as2_" in c:
+        return "ROS2 Nodes"
+    if "tvnc" in c or "xvnc" in c or "novnc" in c or "websockify" in c:
+        return "VNC"
+    if "python" in c:
+        return "User code"
+    return "Other"
+
+
+def friendly_name(p):
+    name, cmd = p.get("name", ""), p.get("cmd", "")
+    if name == "ruby" or "gz sim" in cmd:
+        return (
+            "gz sim (client/GUI)" if ("-g" in cmd or "--gui" in cmd) else "gz sim (server/physics)"
+        )
+    if "ram_entrypoint" in cmd or "manager.py" in cmd:
+        return "RAM Manager"
+    if "manage.py" in cmd:
+        return "Django"
+    if "code.py" in cmd:
+        return "python3 (user code)"
+    if "websockify" in cmd:
+        return "websockify"
+    return name
+
+
+def find_container(override=None):
+    try:
+        out = subprocess.check_output(
+            ["docker", "ps", "--format", "{{.ID}}\t{{.Names}}\t{{.Image}}"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        for line in out.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) < 3:
+                continue
+            cid, cname, cimage = parts
+            if override and (override in cid or override in cname):
+                return cid, cname, cimage
+            if not override and RADI_IMAGE in cimage:
+                return cid, cname, cimage
+    except Exception:
+        pass
+    return None, None, None
+
+
+def _parse_mb(s):
+    s = s.strip()
+    try:
+        n = float(re.sub(r"[^\d.]", "", s))
+        sl = s.lower()
+        if "gib" in sl or "gb" in sl:
+            return n * 1024
+        if "mib" in sl or "mb" in sl:
+            return n
+        if "kib" in sl or "kb" in sl:
+            return n / 1024
+        return n / 1048576
+    except Exception:
+        return 0.0
+
+
+def docker_stats(cid):
+    try:
+        out = subprocess.check_output(
+            [
+                "docker",
+                "stats",
+                "--no-stream",
+                "--format",
+                "{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.PIDs}}",
+                cid,
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        p = out.strip().split("\t")
+        mu, ml = [_parse_mb(x) for x in p[1].split(" / ")]
+        nr, nt = [_parse_mb(x) for x in p[2].split(" / ")]
+        return {
+            "cpu_pct": float(p[0].replace("%", "")),
+            "mem_mb": mu,
+            "mem_limit_mb": ml,
+            "net_rx_mb": nr,
+            "net_tx_mb": nt,
+            "pids": int(p[3]),
+        }
+    except Exception:
+        return None
+
+
+def container_processes(cid):
+    try:
+        r = subprocess.run(
+            ["docker", "exec", cid, "python3", "-c", _PSUTIL_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=12,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return json.loads(r.stdout.strip())
+    except Exception:
+        pass
+    return []
+
+
+# Cached after first successful call so we don't probe both binaries every sample
+_rtf_binary_cache = None
+
+
+def gazebo_rtf(cid):
+    """Query Gazebo RTF via gz/ign topic /stats. Returns float or None."""
+    global _rtf_binary_cache
+    candidates = [_rtf_binary_cache] if _rtf_binary_cache else ["gz", "ign"]
+    for binary in candidates:
+        try:
+            r = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    cid,
+                    "bash",
+                    "-c",
+                    f"timeout 0.8 {binary} topic -e -t /stats 2>/dev/null | grep -m1 real_time_factor",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=4,
+            )
+            m = re.search(r"real_time_factor:\s*([\d.]+)", r.stdout)
+            if m:
+                _rtf_binary_cache = binary
+                return round(float(m.group(1)), 3)
+        except Exception:
+            pass
+    return None
+
+
+def gpu_stats():
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+        v = [x.strip() for x in out.strip().splitlines()[0].split(",")]
+        return {
+            "vendor": "nvidia",
+            "util_pct": float(v[0]),
+            "mem_used_mb": float(v[1]),
+            "mem_total_mb": float(v[2]),
+            "temp_c": float(v[3]),
+        }
+    except Exception:
+        pass
+    try:
+        for card in sorted(os.listdir("/sys/class/drm")):
+            bp = f"/sys/class/drm/{card}/device/gpu_busy_percent"
+            if os.path.exists(bp):
+                with open(bp) as f:
+                    return {
+                        "vendor": "intel_amd",
+                        "util_pct": float(f.read().strip()),
+                        "mem_used_mb": None,
+                        "mem_total_mb": None,
+                        "temp_c": None,
+                    }
+    except Exception:
+        pass
+    return None
+
+
+def host_stats():
+    vm = psutil.virtual_memory()
+    return {
+        "cpu_pct": psutil.cpu_percent(interval=None),
+        "mem_used_gb": round(vm.used / 1024**3, 2),
+        "mem_total_gb": round(vm.total / 1024**3, 1),
+    }
+
+
+def detect_exercise(processes):
+    """Parse gz sim / gzserver cmdline to extract the active world name."""
+    for p in processes:
+        cmd, name = p.get("cmd", ""), p.get("name", "")
+        is_sim = (
+            "gzserver" in name
+            or "gzserver" in cmd
+            or ("gz sim" in cmd and ("-s " in cmd or "-r " in cmd))
+        )
+        if is_sim:
+            m = re.search(r"[/\\]([\w_-]+)\.world", cmd)
+            if m:
+                return m.group(1)
+    return None
+
+
+def save_session(path, samples, meta):
+    with open(path, "w") as f:
+        json.dump({"metadata": meta, "samples": samples}, f, separators=(",", ":"))

--- a/scripts/radi_monitor/lib/report.py
+++ b/scripts/radi_monitor/lib/report.py
@@ -1,0 +1,330 @@
+"""
+report.py — HTML report generation and PDF export for radi_monitor.
+
+Builds a self-contained HTML file (all charts embedded as base64 PNG) and
+optionally converts it to PDF using weasyprint.
+"""
+
+from datetime import datetime
+
+try:
+    from weasyprint import HTML as WeasyHTML
+
+    PDF_AVAILABLE = True
+except ImportError:
+    PDF_AVAILABLE = False
+
+from .analysis import (
+    _dur,
+    get_exercise_events,
+    measurement_summary,
+    per_exercise_stats,
+    process_inventory,
+    session_summary,
+)
+from .charts import (
+    chart_category_cpu,
+    chart_cpu,
+    chart_gpu,
+    chart_memory,
+    chart_network,
+    chart_process_bars,
+    chart_rtf,
+)
+from .collector import CATEGORY_COLOR
+
+_CSS = """
+body{font-family:Arial,sans-serif;font-size:14px;line-height:1.6;
+     max-width:1300px;margin:0 auto;padding:24px;color:#222;background:#fff}
+h1{font-size:21px;border-bottom:3px solid #d32f2f;padding-bottom:6px;margin-bottom:4px}
+h2{font-size:14px;margin:28px 0 10px;border-left:4px solid #1565c0;
+   padding-left:10px;color:#1565c0;text-transform:uppercase;letter-spacing:.5px}
+.meta{color:#777;font-size:12px;margin-bottom:6px}
+.sysinfo{background:#f5f5f5;border-radius:4px;padding:8px 14px;font-size:12px;
+         color:#444;margin-bottom:20px;line-height:1.9}
+.kpi{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px}
+.kb{border:1px solid #ddd;border-radius:6px;padding:11px 16px;min-width:125px;flex:1}
+.kl{font-size:10px;color:#999;text-transform:uppercase;font-weight:bold}
+.kv{font-size:26px;font-weight:bold;color:#d32f2f;line-height:1.1}
+.ks{font-size:11px;color:#888}
+.diag{margin-bottom:20px}
+.d{display:flex;gap:10px;padding:8px 14px;border-radius:4px;margin:5px 0;border-left:5px solid}
+.d.ok{background:#f1f8e9;border-color:#558b2f}
+.d.warn{background:#fff8e1;border-color:#f9a825}
+.d.crit{background:#ffebee;border-color:#d32f2f}
+.dm{font-size:13px;font-weight:bold}
+.df{font-size:12px;color:#555;font-style:italic}
+table{width:100%;border-collapse:collapse;margin:8px 0 22px;font-size:13px}
+th{background:#f0f0f0;border:1px solid #ddd;padding:8px 12px;
+   text-align:left;font-size:11px;text-transform:uppercase;color:#555}
+td{border:1px solid #eee;padding:7px 12px;vertical-align:middle}
+tr:nth-child(even) td{background:#fafafa}
+.r{text-align:right;font-variant-numeric:tabular-nums}
+.hi{color:#d32f2f;font-weight:bold}
+.mid{color:#e65100;font-weight:bold}
+.okv{color:#2e7d32}
+.tagm{background:#ede7f6;color:#4a148c;padding:2px 7px;border-radius:3px;
+      font-size:11px;font-weight:bold}
+.dot{display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:5px}
+.chart{margin:8px 0 26px}
+.chart img{max-width:100%;border:1px solid #eee;border-radius:4px;display:block}
+.rtf-ok{color:#2e7d32;font-weight:bold}
+.rtf-warn{color:#e65100;font-weight:bold}
+.rtf-bad{color:#d32f2f;font-weight:bold}
+footer{color:#bbb;font-size:11px;text-align:center;margin-top:40px;
+       padding-top:12px;border-top:1px solid #eee}
+@media print{.chart img{page-break-inside:avoid}h2{page-break-after:avoid}}
+"""
+
+
+def _cpu_cls(v):
+    return "hi" if v > 200 else "mid" if v > 80 else "okv"
+
+
+def _rtf_cell(v):
+    if v is None:
+        return "—"
+    cls = "rtf-ok" if v >= 0.95 else "rtf-warn" if v >= 0.80 else "rtf-bad"
+    return f'<span class="{cls}">{v:.3f}</span>'
+
+
+def generate_report(samples, meta, output_base, verbose=False):
+    def _log(*args, **kwargs):
+        if verbose:
+            print(*args, **kwargs)
+
+    sysinfo = meta.get("sysinfo", {})
+    manual_events = meta.get("manual_events", [])
+    session_start = meta.get("session_start", "")
+    cpu_threads = sysinfo.get("cpu_threads", 1)
+
+    exercise_events = get_exercise_events(samples, manual_events)
+    summary = session_summary(samples, cpu_threads)
+    exc_stats = per_exercise_stats(samples, exercise_events)
+    metrics_rows = measurement_summary(samples, summary)
+    inventory = process_inventory(samples)
+
+    _log("  rendering CPU chart...", end=" ", flush=True)
+    img_cpu = chart_cpu(samples, exercise_events, cpu_threads)
+    _log("done")
+    _log("  rendering RTF chart...", end=" ", flush=True)
+    img_rtf = chart_rtf(samples, exercise_events)
+    _log("done" if img_rtf else "no RTF data")
+    _log("  rendering category CPU chart...", end=" ", flush=True)
+    img_cat = chart_category_cpu(samples, exercise_events)
+    _log("done")
+    _log("  rendering process bars...", end=" ", flush=True)
+    img_proc = chart_process_bars(inventory)
+    _log("done")
+    _log("  rendering memory chart...", end=" ", flush=True)
+    img_mem = chart_memory(samples, exercise_events)
+    _log("done")
+    _log("  rendering GPU chart...", end=" ", flush=True)
+    img_gpu = chart_gpu(samples, exercise_events)
+    _log("done" if img_gpu else "no GPU data")
+    _log("  rendering network chart...", end=" ", flush=True)
+    img_net = chart_network(samples)
+    _log("done" if img_net else "skipped (no significant traffic)")
+
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    has_gpu = summary.get("gpu_avg") is not None
+
+    # System info block — includes nvidia-smi output if available
+    gpu_str = " · ".join(sysinfo.get("gpus", ["not detected"]))
+    cgpu = meta.get("container_gpu")
+    cgpu_str = f"yes — {cgpu}" if cgpu else "not accessible (container started without --gpus all)"
+    nvidia_smi_html = ""
+    if sysinfo.get("nvidia_smi"):
+        nvidia_smi_html = (
+            f'<details style="margin-top:6px">'
+            f'<summary style="cursor:pointer;font-size:11px;color:#1565c0">nvidia-smi output</summary>'
+            f'<pre style="font-size:10px;background:#f8f8f8;padding:8px;border-radius:3px;'
+            f'overflow-x:auto;margin-top:4px">{sysinfo["nvidia_smi"]}</pre></details>'
+        )
+    sysblock = (
+        f'<div class="sysinfo">'
+        f'<strong>CPU:</strong> {sysinfo.get("cpu","?")} '
+        f'({sysinfo.get("cpu_cores","?")} cores / {sysinfo.get("cpu_threads","?")} threads)'
+        f" &nbsp;·&nbsp; <strong>RAM:</strong> {sysinfo.get('ram_gb','?')} GiB<br>"
+        f"<strong>Host GPU:</strong> {gpu_str}<br>"
+        f"<strong>Container GPU access:</strong> {cgpu_str}<br>"
+        f'<strong>OS:</strong> {sysinfo.get("os","?")} (kernel {sysinfo.get("kernel","?")})'
+        f" &nbsp;·&nbsp; "
+        f'<strong>Image:</strong> {meta.get("image","jderobot/robotics-backend:latest")}'
+        f' &nbsp;·&nbsp; <strong>Container:</strong> {meta.get("container","?")}'
+        f"{nvidia_smi_html}"
+        f"</div>"
+    )
+
+    rtf_val = f"{summary['rtf_avg']:.3f}" if summary.get("rtf_avg") is not None else "N/A"
+    rtf_sub = (
+        f"min {summary['rtf_min']:.3f}"
+        if summary.get("rtf_min") is not None
+        else "no simulation detected"
+    )
+    kpi = (
+        f'<div class="kpi">'
+        f'<div class="kb"><div class="kl">Container CPU</div>'
+        f'<div class="kv">{summary["cpu_avg"]}%</div>'
+        f'<div class="ks">avg · peak {summary["cpu_peak"]}% · max {summary["cpu_max_pct"]}%</div></div>'
+        f'<div class="kb"><div class="kl">Container RAM</div>'
+        f'<div class="kv">{summary["mem_avg_gb"]} GiB</div>'
+        f'<div class="ks">avg · peak {summary["mem_peak_gb"]} GiB</div></div>'
+        f'<div class="kb"><div class="kl">Gazebo RTF</div>'
+        f'<div class="kv">{rtf_val}</div>'
+        f'<div class="ks">{rtf_sub}</div></div>'
+        f'<div class="kb"><div class="kl">GPU</div>'
+        f'<div class="kv">{"{}%".format(summary["gpu_avg"]) if has_gpu else "N/A"}</div>'
+        f'<div class="ks">{"peak {}%".format(summary["gpu_peak"]) if has_gpu else "not detected"}'
+        f"</div></div>"
+        f'<div class="kb"><div class="kl">Host CPU</div>'
+        f'<div class="kv">{summary["host_cpu_avg"]}%</div>'
+        f'<div class="ks">avg during session</div></div>'
+        f'<div class="kb"><div class="kl">Duration</div>'
+        f'<div class="kv">{_dur(summary["duration"])}</div>'
+        f'<div class="ks">{summary["n"]} samples · every {meta.get("interval_s","?")}s</div></div>'
+        f"</div>"
+    )
+
+    metrics_rows_html = "".join(
+        f'<tr><td>{m}</td><td class="r">{avg}</td><td class="r">{peak}</td>'
+        f'<td style="color:#666;font-size:12px">{detail}</td></tr>\n'
+        for m, avg, peak, detail in metrics_rows
+    )
+    metrics_table = (
+        '<table><tr><th>Metric</th><th class="r">Average</th>'
+        '<th class="r">Peak / Min</th><th>Details</th></tr>'
+        + metrics_rows_html
+        + "</table>"
+    )
+
+    if exc_stats:
+        rows = ""
+        for e in exc_stats:
+            tag = ' <span class="tagm">[manual]</span>' if e["source"] == "manual" else ""
+            name = e["name"].replace("_harmonic", "").replace("_", " ")
+            rows += (
+                f'<tr><td><strong>{name}</strong>{tag}</td>'
+                f'<td class="r">{_dur(e["duration"])}</td>'
+                f'<td class="r {_cpu_cls(e["cpu_avg"])}">{e["cpu_avg"]}%</td>'
+                f'<td class="r {_cpu_cls(e["cpu_peak"])}">{e["cpu_peak"]}%</td>'
+                f'<td class="r">{e["ram_avg"]} GiB</td>'
+                f'<td class="r">{"{}%".format(e["gpu_avg"]) if e["gpu_avg"] is not None else "—"}'
+                f"</td>"
+                f'<td class="r">{_rtf_cell(e["rtf_avg"])}</td>'
+                f'<td class="r">{_rtf_cell(e["rtf_min"])}</td></tr>\n'
+            )
+        exc_table = (
+            '<table><tr><th>Exercise</th><th class="r">Duration</th>'
+            '<th class="r">CPU avg</th><th class="r">CPU peak</th>'
+            '<th class="r">RAM avg</th><th class="r">GPU avg</th>'
+            '<th class="r">RTF avg</th><th class="r">RTF min</th></tr>'
+            + rows
+            + "</table>"
+        )
+    else:
+        exc_table = (
+            '<p style="color:#999;padding:8px 0">No exercises detected. '
+            "Use manual tagging: type a name and press Enter while monitoring.</p>"
+        )
+
+    proc_rows = ""
+    for p in inventory:
+        color = CATEGORY_COLOR.get(p["cat"], "#9e9e9e")
+        proc_rows += (
+            f'<tr><td><code>{p["name"]}</code></td>'
+            f'<td><span class="dot" style="background:{color}"></span>'
+            f'<span style="color:{color};font-size:11px">{p["cat"]}</span></td>'
+            f'<td class="r {_cpu_cls(p["avg_cpu"])}">{p["avg_cpu"]}%</td>'
+            f'<td class="r {_cpu_cls(p["peak_cpu"])}">{p["peak_cpu"]}%</td>'
+            f'<td class="r">{p["avg_mem"]:.0f} MB</td>'
+            f'<td class="r">{p["pct_time"]}%</td></tr>\n'
+        )
+    proc_table = (
+        "<table><tr><th>Process</th><th>Category</th>"
+        '<th class="r">CPU avg</th><th class="r">CPU peak</th>'
+        '<th class="r">RAM avg</th><th class="r">% time active</th></tr>'
+        + proc_rows
+        + "</table>"
+    )
+
+    rtf_section = (
+        f'<h2>Gazebo RTF</h2>'
+        f'<div class="chart"><img src="data:image/png;base64,{img_rtf}"></div>'
+        if img_rtf
+        else ""
+    )
+    cat_section = (
+        f'<h2>CPU by category</h2>'
+        f'<div class="chart"><img src="data:image/png;base64,{img_cat}"></div>'
+        if img_cat
+        else ""
+    )
+    gpu_section = (
+        f'<h2>GPU</h2>'
+        f'<div class="chart"><img src="data:image/png;base64,{img_gpu}"></div>'
+        if img_gpu
+        else ""
+    )
+    net_section = (
+        f'<h2>Network I/O</h2>'
+        f'<div class="chart"><img src="data:image/png;base64,{img_net}"></div>'
+        if img_net
+        else ""
+    )
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>RADI Performance Report — {session_start}</title>
+<style>{_CSS}</style>
+</head>
+<body>
+<h1>RADI Performance Report</h1>
+<div class="meta">
+Session: <strong>{session_start}</strong> → <strong>{now}</strong>
+&nbsp;·&nbsp; Report generated: {now}
+&nbsp;·&nbsp; <em>PDF: Ctrl+P → Save as PDF in your browser</em>
+</div>
+{sysblock}
+{kpi}
+<h2>Session metrics</h2>
+{metrics_table}
+<h2>Resource usage per exercise</h2>
+{exc_table}
+<h2>CPU</h2>
+<div class="chart"><img src="data:image/png;base64,{img_cpu}"></div>
+{rtf_section}
+{cat_section}
+<h2>CPU per process</h2>
+<div class="chart"><img src="data:image/png;base64,{img_proc}"></div>
+{gpu_section}
+<h2>Memory</h2>
+<div class="chart"><img src="data:image/png;base64,{img_mem}"></div>
+{net_section}
+<h2>Process inventory</h2>
+{proc_table}
+<footer>jderobot/robotics-backend · radi_monitor · {now}</footer>
+</body>
+</html>"""
+
+    html_path = output_base + ".html"
+    pdf_path = output_base + ".pdf"
+
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    if PDF_AVAILABLE:
+        _log("  generating PDF...", end=" ", flush=True)
+        try:
+            WeasyHTML(filename=html_path).write_pdf(pdf_path)
+            _log("done")
+        except Exception as e:
+            _log(f"failed: {e}")
+            pdf_path = None
+    else:
+        pdf_path = None
+
+    return html_path, pdf_path, summary

--- a/scripts/radi_monitor/monitor.py
+++ b/scripts/radi_monitor/monitor.py
@@ -1,0 +1,285 @@
+"""
+monitor.py — Entry point for radi_monitor.
+
+This is the only file you need to run. Helper modules live in lib/:
+    lib/collector.py  — Docker/container/GPU/host data collection
+    lib/analysis.py   — Statistics, exercise events, measurement summary
+    lib/charts.py     — Matplotlib chart generation
+    lib/report.py     — HTML template, CSS, PDF export
+
+Reports are written to /tmp/ by default (override with --output).
+
+How it works:
+    Attaches to a running jderobot/robotics-backend Docker container and samples
+    at a configurable interval: container CPU/RAM (docker stats), per-process CPU/RAM
+    (psutil inside the container), Gazebo RTF (/stats topic), GPU utilization
+    (nvidia-smi or /sys/class/drm), and host CPU/RAM. All five collectors run in
+    parallel to minimise overhead.
+
+    On Ctrl+C the session is flushed to JSON and a self-contained HTML report
+    (with embedded charts) is generated. A PDF is produced automatically if
+    weasyprint is installed.
+
+Exercise detection:
+    Automatic — the active .world filename is parsed from the gz sim / gzserver
+    cmdline. Manual tagging is also supported: type a name and press Enter at any
+    time to label the current period; an empty Enter clears the tag.
+
+Usage:
+    python3 monitor.py
+    python3 monitor.py --interval 5
+    python3 monitor.py --output /tmp/my_session
+    python3 monitor.py --container <name_or_id>
+    python3 monitor.py --verbose
+
+Dependencies:
+    pip3 install psutil matplotlib weasyprint
+"""
+
+import argparse
+import queue
+import signal
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+
+import psutil
+
+from lib.analysis import _dur, get_exercise_events
+from lib.collector import (
+    check_container_gpu,
+    collect_system_info,
+    container_processes,
+    detect_exercise,
+    docker_stats,
+    find_container,
+    gazebo_rtf,
+    gpu_stats,
+    host_stats,
+    save_session,
+)
+from lib.report import PDF_AVAILABLE, generate_report
+
+VERBOSE = False
+
+
+def log(*args, **kwargs):
+    if VERBOSE:
+        print(*args, **kwargs)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Performance monitor for jderobot/robotics-backend"
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        help="Sampling interval in seconds (default: 3)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output base path without extension (default: /tmp/radi_TIMESTAMP)",
+    )
+    parser.add_argument(
+        "--container",
+        default=None,
+        help="Container name or ID (auto-detected if omitted)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print internal progress messages",
+    )
+    args = parser.parse_args()
+
+    global VERBOSE
+    VERBOSE = args.verbose
+
+    ts_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base = args.output or f"/tmp/radi_{ts_str}"
+
+    print(f"Output: {base}.html / .pdf / .json")
+    log("Collecting system info...", end=" ", flush=True)
+    sysinfo = collect_system_info()
+    log(sysinfo.get("cpu", "?")[:50])
+
+    input_queue: queue.Queue = queue.Queue()
+
+    def _stdin_reader():
+        while True:
+            try:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                input_queue.put(line.rstrip("\n"))
+            except Exception:
+                break
+
+    threading.Thread(target=_stdin_reader, daemon=True).start()
+    psutil.cpu_percent(interval=None)
+
+    samples = []
+    manual_events = []
+    manual_tag = None
+    container_id = None
+    container_name = None
+    container_img = None
+    session_start = None
+    last_exercise = None
+    running = True
+    header_printed = False
+    meta = {}
+
+    def on_stop(sig, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGINT, on_stop)
+    signal.signal(signal.SIGTERM, on_stop)
+
+    pool = ThreadPoolExecutor(max_workers=5)
+    try:
+        while running:
+            try:
+                while True:
+                    typed = input_queue.get_nowait().strip()
+                    t_now = (time.time() - (meta.get("_start_time") or time.time()))
+                    if typed:
+                        manual_tag = typed
+                        manual_events.append({"t": round(t_now, 2), "name": manual_tag})
+                        print(f"[tag] {manual_tag} at t={t_now:.1f}s")
+                    else:
+                        manual_tag = None
+                        print("[tag] cleared")
+            except queue.Empty:
+                pass
+
+            if container_id is None:
+                container_id, container_name, container_img = find_container(args.container)
+                if container_id is None:
+                    print("Waiting for container...", end="\r")
+                    time.sleep(2)
+                    continue
+                start_time = time.time()
+                session_start = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                container_gpu = check_container_gpu(container_id)
+                meta = {
+                    "container": container_name,
+                    "image": container_img or "jderobot/robotics-backend:latest",
+                    "interval_s": args.interval,
+                    "manual_events": manual_events,
+                    "session_start": session_start,
+                    "sysinfo": sysinfo,
+                    "container_gpu": container_gpu,
+                    "_start_time": start_time,
+                }
+                log(
+                    f"Container GPU: {'yes — ' + container_gpu if container_gpu else 'not accessible'}"
+                )
+                print(f"Monitoring {container_name} ({container_id[:12]}) · {container_img}")
+
+            t0 = time.time()
+            elapsed = t0 - meta["_start_time"]
+            ts = datetime.now().isoformat()
+
+            # Run all five collectors in parallel — reduces effective overhead from ~2.5s to ~1.2s
+            f_cstats = pool.submit(docker_stats, container_id)
+            f_procs = pool.submit(container_processes, container_id)
+            f_rtf = pool.submit(gazebo_rtf, container_id)
+            f_gpu = pool.submit(gpu_stats)
+            f_hst = pool.submit(host_stats)
+            cstats = f_cstats.result()
+            processes = f_procs.result()
+            rtf = f_rtf.result()
+            gpu = f_gpu.result()
+            hst = f_hst.result()
+
+            if cstats is None:
+                print("Container stopped — waiting...")
+                container_id = None
+                time.sleep(3)
+                continue
+
+            auto_exc = detect_exercise(processes)
+            exercise = manual_tag if manual_tag else auto_exc
+
+            sample = {
+                "t": round(elapsed, 2),
+                "ts": ts,
+                "container": cstats,
+                "processes": processes[:40],
+                "exercise": exercise,
+                "exercise_source": "manual" if manual_tag else ("auto" if auto_exc else None),
+                "rtf": rtf,
+                "gpu": gpu,
+                "host": hst,
+            }
+            samples.append(sample)
+
+            if not header_printed:
+                print(f"{'Time':>8}  {'CPU':>9}  {'RAM':>8}  {'GPU':>5}  {'RTF':>6}  Exercise")
+                header_printed = True
+
+            gpu_s = f"{gpu['util_pct']:4.0f}%" if gpu else "  N/A"
+            rtf_s = f"{rtf:.3f}" if rtf is not None else "   N/A"
+            exc_s = (exercise or "—")[:26]
+            new = " ←" if exercise and exercise != last_exercise else ""
+            tag_m = " [M]" if manual_tag else ""
+            print(
+                f"{elapsed:7.1f}s  {cstats['cpu_pct']:8.1f}%  {cstats['mem_mb']:6.0f}MB"
+                f"  {gpu_s}  {rtf_s}  {exc_s}{tag_m}{new}"
+            )
+            last_exercise = exercise
+
+            save_session(base + ".json", samples, meta)
+
+            overhead = time.time() - t0
+            time.sleep(max(0.1, args.interval - overhead))
+    finally:
+        pool.shutdown(wait=False)
+
+    if not samples:
+        print("No samples collected.")
+        return
+
+    session_end = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    meta["session_start"] = meta.get("session_start") or session_end
+    meta.pop("_start_time", None)
+    save_session(base + ".json", samples, meta)
+
+    print("\nGenerating report...")
+    log(f"  {len(samples)} samples over {_dur(samples[-1]['t'])}")
+
+    html_path, pdf_path, summary = generate_report(samples, meta, base, verbose=VERBOSE)
+
+    print(f"Report: {html_path}")
+    if pdf_path:
+        print(f"PDF:    {pdf_path}")
+    elif not PDF_AVAILABLE:
+        print("PDF:    not generated (pip3 install weasyprint --break-system-packages)")
+
+    dur = samples[-1]["t"]
+    excs = [e[1] for e in get_exercise_events(samples, manual_events) if e[1] != "idle"]
+    print(
+        f"\nSession    {session_start} → {session_end}  ({_dur(dur)}, {len(samples)} samples)"
+    )
+    print(
+        f"CPU        avg {summary['cpu_avg']}%  peak {summary['cpu_peak']}%"
+        f"  (of {summary['cpu_max_pct']}% max, {meta['sysinfo'].get('cpu_threads','?')} threads)"
+    )
+    print(f"RAM        avg {summary['mem_avg_gb']} GiB  peak {summary['mem_peak_gb']} GiB")
+    if summary.get("rtf_avg") is not None:
+        print(f"RTF        avg {summary['rtf_avg']}  min {summary['rtf_min']}")
+    if summary.get("gpu_avg") is not None:
+        print(f"GPU        avg {summary['gpu_avg']}%  peak {summary['gpu_peak']}%")
+    if excs:
+        print(f"Exercises  {', '.join(excs)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/radi_monitor/monitor.py
+++ b/scripts/radi_monitor/monitor.py
@@ -218,8 +218,8 @@ def main():
                 "container": cstats,
                 "processes": processes[:40],
                 "exercise": exercise,
-                "exercise_source": "manual" 
-                if manual_tag 
+                "exercise_source": "manual"
+                if manual_tag
                 else ("auto" if auto_exc else None),
                 "rtf": rtf,
                 "gpu": gpu,

--- a/scripts/radi_monitor/monitor.py
+++ b/scripts/radi_monitor/monitor.py
@@ -148,7 +148,7 @@ def main():
             try:
                 while True:
                     typed = input_queue.get_nowait().strip()
-                    t_now = (time.time() - (meta.get("_start_time") or time.time()))
+                    t_now = time.time() - (meta.get("_start_time") or time.time())
                     if typed:
                         manual_tag = typed
                         manual_events.append({"t": round(t_now, 2), "name": manual_tag})
@@ -160,7 +160,9 @@ def main():
                 pass
 
             if container_id is None:
-                container_id, container_name, container_img = find_container(args.container)
+                container_id, container_name, container_img = find_container(
+                    args.container
+                )
                 if container_id is None:
                     print("Waiting for container...", end="\r")
                     time.sleep(2)
@@ -181,7 +183,9 @@ def main():
                 log(
                     f"Container GPU: {'yes — ' + container_gpu if container_gpu else 'not accessible'}"
                 )
-                print(f"Monitoring {container_name} ({container_id[:12]}) · {container_img}")
+                print(
+                    f"Monitoring {container_name} ({container_id[:12]}) · {container_img}"
+                )
 
             t0 = time.time()
             elapsed = t0 - meta["_start_time"]
@@ -214,7 +218,9 @@ def main():
                 "container": cstats,
                 "processes": processes[:40],
                 "exercise": exercise,
-                "exercise_source": "manual" if manual_tag else ("auto" if auto_exc else None),
+                "exercise_source": "manual" 
+                if manual_tag 
+                else ("auto" if auto_exc else None),
                 "rtf": rtf,
                 "gpu": gpu,
                 "host": hst,
@@ -222,7 +228,9 @@ def main():
             samples.append(sample)
 
             if not header_printed:
-                print(f"{'Time':>8}  {'CPU':>9}  {'RAM':>8}  {'GPU':>5}  {'RTF':>6}  Exercise")
+                print(
+                    f"{'Time':>8}  {'CPU':>9}  {'RAM':>8}  {'GPU':>5}  {'RTF':>6}  Exercise"
+                )
                 header_printed = True
 
             gpu_s = f"{gpu['util_pct']:4.0f}%" if gpu else "  N/A"
@@ -272,7 +280,9 @@ def main():
         f"CPU        avg {summary['cpu_avg']}%  peak {summary['cpu_peak']}%"
         f"  (of {summary['cpu_max_pct']}% max, {meta['sysinfo'].get('cpu_threads','?')} threads)"
     )
-    print(f"RAM        avg {summary['mem_avg_gb']} GiB  peak {summary['mem_peak_gb']} GiB")
+    print(
+        f"RAM        avg {summary['mem_avg_gb']} GiB  peak {summary['mem_peak_gb']} GiB"
+    )
     if summary.get("rtf_avg") is not None:
         print(f"RTF        avg {summary['rtf_avg']}  min {summary['rtf_min']}")
     if summary.get("gpu_avg") is not None:

--- a/scripts/radi_monitor/requirements.txt
+++ b/scripts/radi_monitor/requirements.txt
@@ -1,0 +1,3 @@
+psutil
+matplotlib
+weasyprint   # optional — only needed for PDF export


### PR DESCRIPTION

 Add RADI performance monitor for developers

  Descripción

  ## Description

  Adds a developer tool (`scripts/radi_monitor/`) to profile the
  `jderobot/robotics-backend` Docker container at runtime.

  The script samples five data sources in parallel every N seconds
  and generates a self-contained HTML report with embedded charts:

  - **Container CPU / RAM** — via `docker stats` (cgroup accounting)
  - **Per-process CPU / RAM** — via `psutil` executed inside the container
  - **Gazebo RTF** — read from the `/stats` topic (`gz` or `ign`)
  - **GPU utilization / VRAM / temperature** — via `nvidia-smi` or
  `/sys/class/drm`
  - **Host CPU / RAM** — via `psutil` on the host

  Reports include time-series charts, a per-exercise breakdown, a
  process inventory grouped by category (Gazebo, ROS 2, Django, VNC…),
  and an optional PDF export.

  Exercise detection is automatic (parsed from the active `.world`
  filename in the `gz sim` / `gzserver` cmdline) and can also be
  set manually by typing a label and pressing Enter while the monitor
  is running.

  ## Usage

  ```bash
  cd scripts/radi_monitor
  pip3 install -r requirements.txt   # psutil, matplotlib (weasyprint optional)
  python3 monitor.py                 # auto-detects the running container

  Output files are written to /tmp/radi_<timestamp>.{html,json,pdf}.
```
