### PR TITLE
replace PyTorch with minimal CUDA runtime wheels, reduce image by ~4.7 GB

### DIFF
--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -162,22 +162,27 @@ RUN python3.10 -m pip install --no-cache-dir \
   pyulog==1.0.1 pyyaml==5.4.1 requests==2.31.0 serial==0.0.97 six==1.16.0 toml==0.10.2 psutil==5.9.0 \
   onnxruntime-gpu==1.22.0 Pillow==9.0.1 opencv-python==4.5.5.64 watchdog==2.1.5 utm==0.7.0 psycopg2 jedi pyapriltags
 
-# Install PyTorch with CUDA 12.8 support; uninstall training-only nvidia packages
-# (nccl, nvshmem, cufile, cusolver, cusparselt, nvtx, cupti) in the same layer
-# to reduce image size — core inference libs (cublas, cudnn, nvrtc) are kept
-RUN python3.10 -m pip install --no-cache-dir --ignore-installed sympy==1.13.3 \
-    && python3.10 -m pip install --no-cache-dir \
-    --extra-index-url https://download.pytorch.org/whl/cu128 \
-    torch  \
-    && python3.10 -m pip uninstall -y \
-    nvidia-nccl-cu12 \
-    nvidia-nvshmem-cu12 \
-    nvidia-cufile-cu12 \
-    nvidia-cusolver-cu12 \
-    nvidia-cusparselt-cu12 \
-    nvidia-nvtx-cu12 \
-    nvidia-cuda-cupti-cu12 \
-    2>/dev/null || true
+# Install minimal CUDA 12.8 runtime libs for onnxruntime-gpu CUDA EP
+# curand and cufft are hard ldd deps of libonnxruntime_providers_cuda.so
+RUN python3.10 -m pip install --no-cache-dir \
+    numpy \
+    onnx \
+    nvidia-cuda-runtime-cu12==12.8.90 \
+    nvidia-cublas-cu12==12.8.4.1 \
+    nvidia-cudnn-cu12==9.10.2.21 \
+    nvidia-nvjitlink-cu12==12.8.93 \
+    nvidia-cuda-nvrtc-cu12==12.8.93 \
+    nvidia-curand-cu12 \
+    nvidia-cufft-cu12
+
+# Register all pip-installed nvidia .so files with ldconfig so onnxruntime-gpu
+# finds them regardless of whether pip used site-packages or dist-packages
+RUN python3.10 -c "\
+import sysconfig, pathlib; \
+site = pathlib.Path(sysconfig.get_path('purelib')); \
+conf = '\n'.join(str(d) for d in site.glob('nvidia/*/lib') if d.is_dir()); \
+pathlib.Path('/etc/ld.so.conf.d/nvidia-pip.conf').write_text(conf + '\n')" \
+    && ldconfig
 
 # monaco editor
 RUN python3.10 -m pip install --no-cache-dir black==24.10.0

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -162,8 +162,25 @@ RUN python3.10 -m pip install --no-cache-dir \
   pyulog==1.0.1 pyyaml==5.4.1 requests==2.31.0 serial==0.0.97 six==1.16.0 toml==0.10.2 psutil==5.9.0 \
   onnxruntime-gpu==1.22.0 Pillow==9.0.1 opencv-python==4.5.5.64 watchdog==2.1.5 utm==0.7.0 psycopg2 jedi pyapriltags
 
-# Install minimal CUDA 12.8 runtime libs for onnxruntime-gpu CUDA EP
-# curand and cufft are hard ldd deps of libonnxruntime_providers_cuda.so
+# CUDA runtime wheels for onnxruntime-gpu==1.22.0 CUDA Execution Provider.
+#
+# All seven packages below must be upgraded together whenever onnxruntime-gpu
+# is bumped. Compatibility ranges declared by the wheel (via ~= operator):
+#   nvidia-cuda-runtime-cu12  ~= 12.0   nvidia-cuda-nvrtc-cu12 ~= 12.0
+#   nvidia-cublas-cu12        (runtime dep of cudnn)
+#   nvidia-cudnn-cu12         ~=  9.0
+#   nvidia-curand-cu12        ~= 10.0   nvidia-cufft-cu12      ~= 11.0
+#
+# Upgrade checklist:
+#   1. Check the new ORT release notes for CUDA / cuDNN major version changes.
+#   2. Run: pip show onnxruntime-gpu | grep Requires  — to see declared ~= ranges.
+#   3. Pick PyPI versions whose MAJOR matches those ranges (stay on CUDA 12.x,
+#      cuDNN 9.x, curand 10.x, cufft 11.x until ORT itself changes the range).
+#   4. After build, verify inside the container:
+#        python3 -c "import onnxruntime as ort; print(ort.get_available_providers())"
+#      CUDAExecutionProvider must appear first.
+#   5. Run: ldd $(python3 -c "import onnxruntime, os; print(os.path.dirname(onnxruntime.__file__))")/capi/libonnxruntime_providers_cuda.so
+#      Every .so must resolve (no "not found" lines).
 RUN python3.10 -m pip install --no-cache-dir \
     numpy \
     onnx \
@@ -172,8 +189,8 @@ RUN python3.10 -m pip install --no-cache-dir \
     nvidia-cudnn-cu12==9.10.2.21 \
     nvidia-nvjitlink-cu12==12.8.93 \
     nvidia-cuda-nvrtc-cu12==12.8.93 \
-    nvidia-curand-cu12 \
-    nvidia-cufft-cu12
+    nvidia-curand-cu12==10.3.10.19 \
+    nvidia-cufft-cu12==11.4.1.4
 
 # Register all pip-installed nvidia .so files with ldconfig so onnxruntime-gpu
 # finds them regardless of whether pip used site-packages or dist-packages

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -162,9 +162,22 @@ RUN python3.10 -m pip install --no-cache-dir \
   pyulog==1.0.1 pyyaml==5.4.1 requests==2.31.0 serial==0.0.97 six==1.16.0 toml==0.10.2 psutil==5.9.0 \
   onnxruntime-gpu==1.22.0 Pillow==9.0.1 opencv-python==4.5.5.64 watchdog==2.1.5 utm==0.7.0 psycopg2 jedi pyapriltags
 
-# install pytorch with CUDA 12.8 support 
-RUN python3.10 -m pip install --no-cache-dir --ignore-installed sympy==1.13.3
-RUN python3.10 -m pip install --no-cache-dir torch --extra-index-url https://download.pytorch.org/whl/cu128
+# Install PyTorch with CUDA 12.8 support; uninstall training-only nvidia packages
+# (nccl, nvshmem, cufile, cusolver, cusparselt, nvtx, cupti) in the same layer
+# to reduce image size — core inference libs (cublas, cudnn, nvrtc) are kept
+RUN python3.10 -m pip install --no-cache-dir --ignore-installed sympy==1.13.3 \
+    && python3.10 -m pip install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cu128 \
+    torch  \
+    && python3.10 -m pip uninstall -y \
+    nvidia-nccl-cu12 \
+    nvidia-nvshmem-cu12 \
+    nvidia-cufile-cu12 \
+    nvidia-cusolver-cu12 \
+    nvidia-cusparselt-cu12 \
+    nvidia-nvtx-cu12 \
+    nvidia-cuda-cupti-cu12 \
+    2>/dev/null || true
 
 # monaco editor
 RUN python3.10 -m pip install --no-cache-dir black==24.10.0

--- a/scripts/RADI/Dockerfile.dependencies_humble
+++ b/scripts/RADI/Dockerfile.dependencies_humble
@@ -28,6 +28,12 @@ ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python3.10/site-packages
 ENV ROS_PYTHON_VERSION=3
 ENV ROS_VERSION=2
 
+# gz.msgs10 Python bindings (installed by gz-harmonic apt package) are compiled
+# with protoc 3.x and cannot create descriptors under protobuf 4.x / 5.x C++
+# extension. Force pure-Python protobuf parser (backward-compatible with all
+# .pb2 files) so gz.msgs10 and onnxruntime-gpu coexist without version pinning.
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
 # Install common tools
 RUN apt-get update && apt-get install -y \
   software-properties-common \
@@ -182,8 +188,6 @@ RUN python3.10 -m pip install --no-cache-dir \
 #   5. Run: ldd $(python3 -c "import onnxruntime, os; print(os.path.dirname(onnxruntime.__file__))")/capi/libonnxruntime_providers_cuda.so
 #      Every .so must resolve (no "not found" lines).
 RUN python3.10 -m pip install --no-cache-dir \
-    numpy \
-    onnx \
     nvidia-cuda-runtime-cu12==12.8.90 \
     nvidia-cublas-cu12==12.8.4.1 \
     nvidia-cudnn-cu12==9.10.2.21 \


### PR DESCRIPTION
Following up on #3856 which eliminated the ghost layer in `Dockerfile.humble`,
  this PR tackles the next major source of image bloat in `Dockerfile.dependencies_humble`.

  ### The Problem

  PyTorch was being installed with full CUDA 12.8 GPU support, even though
  `torch` is not imported anywhere in RoboticsAcademy or RoboticsInfrastructure.
  It was only ever there as a side-effect of providing CUDA shared libraries for
  `onnxruntime-gpu`. The full GPU stack weighs approximately 4.7 GB.

  ### What Changed

  **Replaced this:**
  ```dockerfile
  RUN pip install torch --extra-index-url https://download.pytorch.org/whl/cu128

  With this — the seven CUDA 12.8 wheels that onnxruntime-gpu==1.22.0
  actually needs at runtime:
  RUN pip install \
      nvidia-cuda-runtime-cu12==12.8.90 \
      nvidia-cublas-cu12==12.8.4.1 \
      nvidia-cudnn-cu12==9.10.2.21 \
      nvidia-nvjitlink-cu12==12.8.93 \
      nvidia-cuda-nvrtc-cu12==12.8.93 \
      nvidia-curand-cu12==10.3.10.19 \
      nvidia-cufft-cu12==11.4.1.4
```
      
  All versions are hard-pinned and were verified against onnxruntime-gpu's own
  declared compatibility ranges (inspected via importlib.metadata inside the
  built container). A ldconfig step is added so the pip-installed .so files
  are visible to the dynamic linker regardless of site-packages layout.

  Also reorganized the PCL and IndustrialRobots workspace setup into a dedicated,
  clearly separated block so the build order is explicit and easier to follow.

  Verification
  
  Built and tested as jderobot/robotics-academy:gsoc_test_image_v6.

  ## GPU Execution Provider confirmed active
  docker run --rm --gpus all gsoc_test_image_v6 \
    python3 -c "import onnxruntime as ort; print(ort.get_available_providers())"
  ## Output: ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']

  Launched the full stack via Docker Compose with GPU passthrough and opened
  http://localhost:7164 — the platform loads normally, exercises launch as
  expected.

 ## Important : The testing with regards to deep learning exercises is still remaining 
