### PR TITLE
Fix mandatory HAL dependency for ROS2 direct usage in cpp templates

### DIFF
--- a/exercises/follow_line/cpp_template/main.cpp
+++ b/exercises/follow_line/cpp_template/main.cpp
@@ -1,12 +1,13 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
 #include <thread>
 #include <string>
 #include <iostream>
-
 class SystemBootstrapper {
 public:
     static void init_hal() {
@@ -17,7 +18,6 @@ public:
         WebGUI::init();
     }
 };
-
 void start_console()
 {
   int virtual_terminal = 0;
@@ -30,21 +30,16 @@ void start_console()
       virtual_terminal = std::stoi(filename);
     }
   }
-
   const std::string v_terminal_str = "/dev/pts/" + std::to_string(virtual_terminal);
-
   if (freopen(v_terminal_str.c_str(), "w", stdout) == NULL) {}
   if (freopen(v_terminal_str.c_str(), "w", stderr) == NULL) {}
   if (freopen(v_terminal_str.c_str(), "w", stdin) == NULL) {}
 }
-
 int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
   start_console();
-
   SystemBootstrapper::init_webgui();
-
 #ifdef USER_NODE
   rclcpp::executors::SingleThreadedExecutor executor;
   auto user_node = std::make_shared<UserNode>();
@@ -52,14 +47,11 @@ int main(int argc, char *argv[])
   executor.spin();
 #else
   SystemBootstrapper::init_hal();
-
   std::thread user_thread(exercise);
-
   if (user_thread.joinable()) {
     user_thread.join();
   }
 #endif
-
   rclcpp::shutdown();
   return 0;
 }

--- a/exercises/global_navigation/cpp_template/main.cpp
+++ b/exercises/global_navigation/cpp_template/main.cpp
@@ -1,5 +1,7 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
@@ -12,7 +14,7 @@ public:
     static void init_hal() {
         HAL::init();
     }
-    
+
     static void init_webgui() {
         WebGUI::init();
     }

--- a/exercises/laser_mapping/cpp_template/main.cpp
+++ b/exercises/laser_mapping/cpp_template/main.cpp
@@ -1,5 +1,7 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
@@ -12,7 +14,7 @@ public:
     static void init_hal() {
         HAL::init();
     }
-    
+
     static void init_webgui() {
         WebGUI::init();
     }

--- a/exercises/marker_visual_loc/cpp_template/main.cpp
+++ b/exercises/marker_visual_loc/cpp_template/main.cpp
@@ -1,5 +1,7 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
@@ -12,7 +14,7 @@ public:
     static void init_hal() {
         HAL::init();
     }
-    
+
     static void init_webgui() {
         WebGUI::init();
     }

--- a/exercises/montecarlo_laser_loc/cpp_template/main.cpp
+++ b/exercises/montecarlo_laser_loc/cpp_template/main.cpp
@@ -1,5 +1,7 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
@@ -12,7 +14,7 @@ public:
     static void init_hal() {
         HAL::init();
     }
-    
+
     static void init_webgui() {
         WebGUI::init();
     }

--- a/exercises/obstacle_avoidance/cpp_template/main.cpp
+++ b/exercises/obstacle_avoidance/cpp_template/main.cpp
@@ -1,12 +1,13 @@
-#include "HAL.hpp"
 #include "WebGUI.hpp"
+#ifndef USER_NODE
+#include "HAL.hpp"
+#endif
 #include "academy.cpp"
 #include "rclcpp/rclcpp.hpp"
 #include <filesystem>
 #include <thread>
 #include <string>
 #include <iostream>
-
 class SystemBootstrapper {
 public:
     static void init_hal() {
@@ -17,7 +18,6 @@ public:
         WebGUI::init();
     }
 };
-
 void start_console()
 {
   int virtual_terminal = 0;
@@ -30,21 +30,16 @@ void start_console()
       virtual_terminal = std::stoi(filename);
     }
   }
-
   const std::string v_terminal_str = "/dev/pts/" + std::to_string(virtual_terminal);
-
   if (freopen(v_terminal_str.c_str(), "w", stdout) == NULL) {}
   if (freopen(v_terminal_str.c_str(), "w", stderr) == NULL) {}
   if (freopen(v_terminal_str.c_str(), "w", stdin) == NULL) {}
 }
-
 int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
   start_console();
-
   SystemBootstrapper::init_webgui();
-
 #ifdef USER_NODE
   rclcpp::executors::SingleThreadedExecutor executor;
   auto user_node = std::make_shared<UserNode>();
@@ -52,14 +47,11 @@ int main(int argc, char *argv[])
   executor.spin();
 #else
   SystemBootstrapper::init_hal();
-
   std::thread user_thread(exercise);
-
   if (user_thread.joinable()) {
     user_thread.join();
   }
 #endif
-
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Fixes the issue reported in #3806 where building a pure ROS 2 solution 
(without the Simple API) fails to compile because `#include "HAL.hpp"` 
was unconditionally included at the top of the generated `main.cpp`.

HAL.hpp is now wrapped in a `#ifndef USER_NODE` guard, so it is only 
included when actually needed.

Affected exercises:
- follow_line
- obstacle_avoidance
- global_navigation
- laser_mapping
- marker_visual_loc
- montecarlo_laser_loc