### PR TITLE
fix: active session not clearing on tab close (Mac/Windows)

### DIFF
--- a/academy/views.py
+++ b/academy/views.py
@@ -95,12 +95,11 @@ def enter_exercise(fal, request):
         "url": project.url,
     }
 
-    # FIX:https://github.com/JdeRobot/RoboticsAcademy/issues/3510
-    # global active_project
-    # if active_project is None:
-    #     active_project = project_id
-    # else:
-    #     raise Exception("Alredy open session")
+    global active_project
+    if active_project is None:
+        active_project = project_id
+    else:
+        raise Exception("Already open session")
 
     # Create filesystem base
     path = fal.exercise_path(project_id)

--- a/react_frontend/src/routes/Project.tsx
+++ b/react_frontend/src/routes/Project.tsx
@@ -35,17 +35,18 @@ const Exercise = () => {
   });
 
   useEffect(() => {
-    window.addEventListener("beforeunload", () => exitProject());
+      const handleExit = () => exitProject();
+      window.addEventListener("pagehide", handleExit);
 
-    return () => {
-      window.removeEventListener("beforeunload", () => exitProject());
-      // This is to fix this: fires twice thanks to react Strict mode
-      if (hasRender.current || process.env.NODE_ENV !== "development") {
-        exitProject();
-      }
-      hasRender.current = true;
-    };
-  }, []);
+      return () => {
+        window.removeEventListener("pagehide", handleExit);
+        // This is to fix this: fires twice thanks to react Strict mode
+        if (hasRender.current || process.env.NODE_ENV !== "development") {
+          exitProject();
+        }
+        hasRender.current = true;
+      };
+    }, []);
 
   // TODO: only tmp
   const additionalEntrypoints = data.tags.includes("MULTI-ENTRYPOINT") ? ["drone_1/academy.py"] : undefined


### PR DESCRIPTION
Fixes #3510

Root cause: `beforeunload` fetch/beacon is dropped by Chrome on Mac/Windows 
before reaching the server, leaving active_project set permanently.

Changes:
- `Project.tsx`: replaced `beforeunload` with `pagehide` which fires reliably 
  on all platforms including Mac/Windows on tab close and navigation
- `Project.tsx`: fixed `removeEventListener` bug — was passing a new anonymous 
  function each time so the listener was never actually removed
- `views.py`: re-enabled the active_project session check that was temporarily 
  disabled in #3514, now that cleanup is reliable
- `views.py`: fixed typo "Alredy" → "Already"