### PR TITLE
Fix active session tracking bug  (#3510)

### DIFF
--- a/academy/error_handler.py
+++ b/academy/error_handler.py
@@ -9,6 +9,7 @@ from functools import wraps
 import json
 import logging
 from .exceptions import (
+    ActiveSessionExists,
     BinaryNotSupported,
     ResourceAlreadyExistsHelpers,
     ResourceNotExists,
@@ -22,6 +23,7 @@ from django.conf import settings
 from copy import copy
 
 CUSTOM_EXCEPTIONS = (
+    ActiveSessionExists,
     ResourceNotExists,
     ResourceAlreadyExists,
     ParameterInvalid,

--- a/academy/exceptions.py
+++ b/academy/exceptions.py
@@ -68,3 +68,16 @@ class BinaryNotSupported(Exception):
 
     def __str__(self):
         return f"{self.message}"
+
+
+class ActiveSessionExists(Exception):
+    """Exception raised when an exercise session is already active in another tab/window."""
+
+    def __init__(self, msg="You have open a Robotics Academy exercise in another tab or window"):
+        self.message = msg
+        super().__init__(self.message)
+        self.error_code = 409
+
+    def __str__(self):
+        return f"{self.message}"
+

--- a/academy/tests.py
+++ b/academy/tests.py
@@ -287,11 +287,11 @@ class EnterExerciseViewTests(TestCase):
             res1 = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex1"})
             self.assertEqual(res1.status_code, 200)
 
-            # 2. Re-enter ex1 (same exercise refresh)
-            res1_re = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex1"})
-            self.assertEqual(res1_re.status_code, 200)
+            # 2. Try entering ex1 again in a 2nd tab while ex1 is active -> should fail with 409 Conflict
+            res1_conflict = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex1"})
+            self.assertEqual(res1_conflict.status_code, 409)
 
-            # 3. Enter ex2 while ex1 is active -> should fail with 409 Conflict
+            # 3. Try entering ex2 while ex1 is active -> should fail with 409 Conflict
             res2_conflict = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex2"})
             self.assertEqual(res2_conflict.status_code, 409)
 

--- a/academy/tests.py
+++ b/academy/tests.py
@@ -264,8 +264,49 @@ class EnterExerciseViewTests(TestCase):
             self.assertIn("info", data)
             self.assertEqual(data["info"]["name"], "Test Enter")
         finally:
+            self.client.post("/academy/exit_exercise/")
             error_handler.local_fal = orig
             shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_active_session_tracking_and_exit(self):
+        import tempfile, shutil
+        from academy import error_handler
+        from academy.file_access import FAL_RA
+
+        tmp = tempfile.mkdtemp()
+        orig = error_handler.local_fal
+        error_handler.local_fal = FAL_RA(tmp, os.path.join(tmp, "exercises"))
+        try:
+            _make_exercise("test_ex1", "Test Exercise 1")
+            _make_exercise("test_ex2", "Test Exercise 2")
+
+            # Reset active project state before starting test
+            self.client.post("/academy/exit_exercise/")
+
+            # 1. Enter ex1
+            res1 = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex1"})
+            self.assertEqual(res1.status_code, 200)
+
+            # 2. Re-enter ex1 (same exercise refresh)
+            res1_re = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex1"})
+            self.assertEqual(res1_re.status_code, 200)
+
+            # 3. Enter ex2 while ex1 is active -> should fail with 409 Conflict
+            res2_conflict = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex2"})
+            self.assertEqual(res2_conflict.status_code, 409)
+
+            # 4. Exit ex1
+            exit_res = self.client.post("/academy/exit_exercise/")
+            self.assertEqual(exit_res.status_code, 200)
+
+            # 5. Enter ex2 after exit -> should succeed
+            res2_success = self.client.get("/academy/enter_exercise/", {"project_id": "test_ex2"})
+            self.assertEqual(res2_success.status_code, 200)
+        finally:
+            self.client.post("/academy/exit_exercise/")
+            error_handler.local_fal = orig
+            shutil.rmtree(tmp, ignore_errors=True)
+
 
 
 class FileManagementViewTests(TestCase):

--- a/academy/views.py
+++ b/academy/views.py
@@ -12,6 +12,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.decorators import api_view
 
 from academy.exceptions import (
+    ActiveSessionExists,
     ResourceAlreadyExistsHelpers,
 )
 from academy.project_view import EntryEncoder, exists_in_helpers
@@ -95,12 +96,11 @@ def enter_exercise(fal, request):
         "url": project.url,
     }
 
-    # FIX:https://github.com/JdeRobot/RoboticsAcademy/issues/3510
-    # global active_project
-    # if active_project is None:
-    #     active_project = project_id
-    # else:
-    #     raise Exception("Alredy open session")
+    global active_project
+    if active_project is None or active_project == project_id:
+        active_project = project_id
+    else:
+        raise ActiveSessionExists()
 
     # Create filesystem base
     path = fal.exercise_path(project_id)
@@ -117,6 +117,7 @@ def enter_exercise(fal, request):
     return JsonResponse({"success": True, "info": info})
 
 
+@csrf_exempt
 @error_wrapper("POST")
 def exit_exercise(fal, request):
     """

--- a/academy/views.py
+++ b/academy/views.py
@@ -97,7 +97,7 @@ def enter_exercise(fal, request):
     }
 
     global active_project
-    if active_project is None or active_project == project_id:
+    if active_project is None:
         active_project = project_id
     else:
         raise ActiveSessionExists()

--- a/react_frontend/src/api/api.ts
+++ b/react_frontend/src/api/api.ts
@@ -44,7 +44,14 @@ const exitProject = async () => {
     const csfr = getCookie("csrftoken");
     if (csfr !== undefined) {
       data.append("csrfmiddlewaretoken", csfr);
+    }
+    const beaconSent =
+      typeof navigator !== "undefined" &&
+      typeof navigator.sendBeacon === "function" &&
       navigator.sendBeacon(apiUrl, data);
+
+    if (!beaconSent) {
+      axios.post(apiUrl, data, axiosExtra()).catch(() => {});
     }
   } catch (e: unknown) {
     const error = e as ApiError;

--- a/react_frontend/src/routes/Project.tsx
+++ b/react_frontend/src/routes/Project.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { Params, useLoaderData } from "react-router";
 import { lazy, Suspense } from "react";
 import WebGUIPreview from "Components/visualizers/WebGUIPreview";
@@ -22,7 +22,6 @@ export const loader = async ({
 };
 
 const Exercise = () => {
-  const hasRender = useRef(false);
   const data = useLoaderData<Omit<ExerciseData, "worlds">>();
 
   const WebGui = lazy(async () => {
@@ -35,17 +34,21 @@ const Exercise = () => {
   });
 
   useEffect(() => {
-    window.addEventListener("beforeunload", () => exitProject());
+    const handleBeforeUnload = () => {
+      exitProject();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
 
     return () => {
-      window.removeEventListener("beforeunload", () => exitProject());
-      // This is to fix this: fires twice thanks to react Strict mode
-      if (hasRender.current || process.env.NODE_ENV !== "development") {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      if (
+        !window.location.pathname.includes(`/academy/studio/${data.exercise_id}`)
+      ) {
         exitProject();
       }
-      hasRender.current = true;
     };
-  }, []);
+  }, [data.exercise_id]);
 
   // TODO: only tmp
   const additionalEntrypoints = data.tags.includes("MULTI-ENTRYPOINT") ? ["drone_1/academy.py"] : undefined


### PR DESCRIPTION
## Description
Fixes #3510 where RoboticsAcademy allowed multiple exercise sessions or displayed "You have open a Robotics Academy exercise in another tab or window" incorrectly after closing an exercise.

### Changes Made:
- **Backend (`academy/views.py`, `exceptions.py`, `error_handler.py`)**:
  - Enforced strict single active exercise session (`if active_project is None`) so opening any exercise in a 2nd tab triggers the active session warning.
  - Added `@csrf_exempt` to `exit_exercise` endpoint to guarantee beacon/unload POST requests succeed.
  - Registered `ActiveSessionExists` (409 Conflict) exception handler.
- **Frontend (`Project.tsx`, `api.ts`)**:
  - Updated `Project.tsx` so `exitProject()` is only triggered when navigating away from the exercise studio route.
  - Optimized `exitProject` in `api.ts` to use `navigator.sendBeacon` with `axios.post` fallback.
- **Tests (`academy/tests.py`)**:
  - Added Django unit tests verifying single-session enforcement for both same and different exercises, along with clean exit and re-entry.

## Demonstration

### Before Fix:

https://github.com/user-attachments/assets/38aa3d2f-06cd-49c5-8740-363ed808d14b


### After Fix:

https://github.com/user-attachments/assets/09b06032-4a03-4f88-8b67-5e48e0daed4c

