### PR TITLE
feat(compose): Add rootless Podman + NVIDIA CDI configurations

### DIFF
--- a/compose_cfg/dev_humble_podman_nvidia.yaml
+++ b/compose_cfg/dev_humble_podman_nvidia.yaml
@@ -1,0 +1,68 @@
+# Rootless Podman + NVIDIA via CDI. Run without sudo: sudo selects podman's
+# rootful container store.
+#
+# Needs a one-time host tweak, otherwise podman 4.x rejects the spec that
+# nvidia-ctk generates ('json: unknown field "additionalGids"'):
+#
+#   echo 'NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS=no-additional-gids-for-device-nodes' \
+#     | sudo tee -a /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
+#   sudo systemctl restart nvidia-cdi-refresh.service
+
+services:
+  my-postgres:
+    image: jderobot/robotics-database:latest
+    container_name: world_db
+    networks:
+      - db_network
+    environment:
+      POSTGRES_DB: academy_db
+      POSTGRES_USER: user-dev
+      POSTGRES_PASSWORD: robotics-academy-dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./RoboticsInfrastructure/database/worlds.sql:/docker-entrypoint-initdb.d/1.sql
+      - ./database/exercises/db.sql:/docker-entrypoint-initdb.d/2.sql
+      - ./database/django_auth.sql:/docker-entrypoint-initdb.d/3.sql
+    healthcheck:
+      test: pg_isready -U user-dev -d academy_db
+      interval: 3s
+      timeout: 1s
+      retries: 20
+
+  robotics-academy:
+    image: jderobot/robotics-academy:latest
+    container_name: developer-container
+    networks:
+      - db_network
+    command: "-s"
+    # CDI replaces the nvidia-container-runtime hook: no runtime: nvidia, no
+    # NVIDIA_VISIBLE_DEVICES. It injects /dev/dri too, though rootless access
+    # there still needs a logind seat ACL or the render and video groups.
+    devices:
+      - "nvidia.com/gpu=all"
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    # Needed on SELinux hosts, no-op elsewhere.
+    security_opt:
+      - label=disable
+    ports:
+      - "7164:7164"
+      - "7163:7163"
+      - "6080-6090:6080-6090"
+    volumes:
+      - type: bind
+        source: ./
+        target: /RoboticsAcademy
+      - type: bind
+        source: ./src
+        target: /RoboticsApplicationManager
+      - ./RoboticsInfrastructure/database/worlds.sql:/worlds.sql
+    tty: true
+    stdin_open: true
+    depends_on:
+      my-postgres:
+        condition: service_healthy
+
+networks:
+  db_network:

--- a/compose_cfg/user_humble_podman_nvidia.yaml
+++ b/compose_cfg/user_humble_podman_nvidia.yaml
@@ -1,0 +1,49 @@
+# Rootless Podman + NVIDIA via CDI. Run without sudo: sudo selects podman's
+# rootful container store.
+#
+# Needs a one-time host tweak, otherwise podman 4.x rejects the spec that
+# nvidia-ctk generates ('json: unknown field "additionalGids"'):
+#
+#   echo 'NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS=no-additional-gids-for-device-nodes' \
+#     | sudo tee -a /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
+#   sudo systemctl restart nvidia-cdi-refresh.service
+
+services:
+  my-postgres:
+    image: jderobot/robotics-database:latest
+    container_name: world_db
+    environment:
+      POSTGRES_DB: academy_db
+      POSTGRES_USER: user-dev
+      POSTGRES_PASSWORD: robotics-academy-dev
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: pg_isready -U user-dev -d academy_db
+      interval: 3s
+      timeout: 1s
+      retries: 20
+
+  robotics-academy:
+    image: jderobot/robotics-academy:latest
+    container_name: developer-container
+    command: "-s"
+    # CDI replaces the nvidia-container-runtime hook: no runtime: nvidia, no
+    # NVIDIA_VISIBLE_DEVICES. It injects /dev/dri too, though rootless access
+    # there still needs a logind seat ACL or the render and video groups.
+    devices:
+      - "nvidia.com/gpu=all"
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    # Needed on SELinux hosts, no-op elsewhere.
+    security_opt:
+      - label=disable
+    ports:
+      - "7164:7164"
+      - "7163:7163"
+      - "6080-6090:6080-6090"
+    tty: true
+    stdin_open: true
+    depends_on:
+      my-postgres:
+        condition: service_healthy


### PR DESCRIPTION
# Overview

This PR introduces native Podman Compose configurations for both development and user modes. It is a non-breaking addition: no existing Docker Compose configurations or shell scripts have been modified, ensuring zero impact on existing Docker workflows.

## Architectural Decisions

The existing `*_humble_nvidia.yaml` configurations rely on several Docker-specific mechanisms that are not compatible with Podman. This PR adapts the stack for rootless Podman using native Podman-compatible approaches.

### CDI Instead of Legacy NVIDIA Runtime

Replaced Docker-specific GPU configuration (`--compatibility` resource reservations, `runtime: nvidia`, and `NVIDIA_VISIBLE_DEVICES`) with the standard Container Device Interface (CDI):

```yaml
devices:
  - "nvidia.com/gpu=all"
```

This is the recommended GPU integration mechanism for modern Podman.

### Automatic DRI Device Injection

Since CDI automatically injects the required DRI device nodes, the manual `/dev/dri` volume mounts have been removed.

### User Namespace & SELinux Compatibility

The container continues to run as the default root user inside its user namespace instead of using `userns_mode: keep-id`, as the image relies on hardcoded paths under `/root/`.

Additionally,

```yaml
security_opt:
  - label=disable
```

is enabled to avoid SELinux volume-labeling issues. This acts as a no-op on systems without SELinux.

### Native Podman Networking

Removed the legacy

```yaml
links:
  - my-postgres
```

directive and rely instead on Podman's built-in `aardvark-dns` service discovery.

---

# Host Prerequisites (for Testing)

On Podman 4.x, `nvidia-ctk` generates CDI specifications containing `additionalGids`, producing a CDI v0.7.0 specification that Podman's bundled CDI library rejects.

To generate a Podman-compatible CDI v0.5.0 specification:

```bash
echo 'NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS=no-additional-gids-for-device-nodes' \
  | sudo tee -a /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env

sudo systemctl restart nvidia-cdi-refresh.service
```

If testing on a headless server without desktop session ACLs, ensure the user belongs to both the `render` and `video` groups.

---

# Verification

**Environment**

- Ubuntu 24.04
- Rootless Podman 4.9.3
- NVIDIA GeForce GTX 1650
- Driver 580.173.02
- CDI specification v0.5.0

### Development Mode

Successfully verified end-to-end.

- PostgreSQL initializes correctly and loads all 18 database tables.
- `pg_isready` health checks gate startup correctly.
- Django starts successfully.
- RAM WebSocket launches successfully.

### Hardware GPU Acceleration

Verified that VirtualGL acquires the physical GPU through CDI:

```text
$ podman exec developer-container /opt/VirtualGL/bin/eglinfo egl0 -B

DRI device path: /dev/dri/card1
OpenGL renderer string: NVIDIA GeForce GTX 1650/PCIe/SSE2
OpenGL core profile version string: 4.6.0 NVIDIA 580.173.02
```

### Clean Teardown

`podman compose down` removes containers and networks cleanly without namespace leakage.


# Scope

This PR is intentionally limited to adding native Podman Compose configurations.

Subsequent PRs will cover:

- Integrating the required `-p` engine flag into the helper scripts, including appropriate rootful/sudo safeguards.
- Updating the developer documentation (`README.md` and `InstructionsForDevelopers.md`) with Podman setup, usage, and troubleshooting guidance.