### PR TITLE
Add -p flag for rootless Podman to the launcher scripts

### DIFF
--- a/scripts/develop_academy.sh
+++ b/scripts/develop_academy.sh
@@ -6,6 +6,7 @@ branch="humble-devel"
 radi_version="humble"
 gpu_mode="false"
 nvidia="false"
+engine="docker"
 compose_file="dev_humble_cpu"
 
 # Function to display help message
@@ -16,20 +17,24 @@ show_help() {
   echo "  -i  Specify the ROS2 version (default: humble)"
   echo "  -g  Enable GPU mode (default: false)"
   echo "  -n  Enable Nvidia support (default: false)"
+  echo "  -p  Use rootless Podman instead of Docker (requires -n for GPU)"
   echo "  -h  Display this help message"
 }
 
 # Function to clean up the containers
 cleanup() {
   echo "Cleaning up..."
-  if [ "$nvidia" = "true" ]; then
-    docker compose --compatibility down
+  if [ "$engine" = "podman" ]; then
+    # Silence the errors for containers podman-compose already removed
+    $compose_cmd down 2>/dev/null
+  elif [ "$nvidia" = "true" ]; then
+    $compose_cmd --compatibility down
   else
-    docker compose down
+    $compose_cmd down
   fi
   rm docker-compose.yaml
   rm react_frontend/checksum.txt
-  
+
   exit 0
 }
 
@@ -55,6 +60,10 @@ while [[ $# -gt 0 ]]; do
             nvidia="true"
             shift 1
             ;;
+        -p)
+            engine="podman"
+            shift 1
+            ;;
         -h | --help) # display Help
             show_help
             exit 0
@@ -67,17 +76,63 @@ while [[ $# -gt 0 ]]; do
    esac
 done
 
+# Set the compose command based on the engine
+if [ "$engine" = "podman" ]; then
+  compose_cmd="podman-compose -p roboticsacademy"
+else
+  compose_cmd="docker compose"
+fi
+
+# Preflight checks
+preflight_checks() {
+  # Podman checks: rootless, binaries and CDI spec
+  if [ "$engine" = "podman" ]; then
+    if [ "$(id -u)" -eq 0 ]; then
+      echo "Error: Rootless Podman must be run without sudo. Execute the script as a standard user."
+      exit 1
+    fi
+
+    for binary in podman podman-compose; do
+      if ! command -v "$binary" &> /dev/null; then
+        echo "Error: $binary is not installed or not in PATH."
+        exit 1
+      fi
+    done
+
+    if [ "$gpu_mode" = "true" ]; then
+      echo "Error: Podman GPU acceleration requires NVIDIA CDI. Use -p -n instead of -p -g."
+      exit 1
+    fi
+
+    # A CDI spec is needed to resolve the nvidia.com/gpu device
+    if [ "$nvidia" = "true" ]; then
+      if ! compgen -G "/var/run/cdi/*.yaml" > /dev/null && \
+         ! compgen -G "/var/run/cdi/*.json" > /dev/null && \
+         ! compgen -G "/etc/cdi/*.yaml"     > /dev/null && \
+         ! compgen -G "/etc/cdi/*.json"     > /dev/null; then
+        echo "Error: No CDI spec found in /var/run/cdi or /etc/cdi."
+        echo "Generate one with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+        exit 1
+      fi
+    fi
+
+    # Podman has no daemon, skip the docker checks
+    return
+  fi
+
+  if ! docker compose version &> /dev/null; then
+    echo "Docker Compose V2 is not installed. Please install it."
+  fi
+}
+
+preflight_checks
+
 # Set up trap to catch interrupt signal (Ctrl+C) and execute cleanup function
 trap 'cleanup' INT
 
 echo "RAM src: $ram_version"
 echo "RAM branch: $branch"
 echo "RoboticsBackend version: $radi_version"
-
-# Check docker compose installation
-if ! docker compose version &> /dev/null; then
-  echo "Docker Compose V2 is not installed. Please install it."
-fi
 
 # Clone the desired RAM fork and branch
 if ! [ -d src ]; then
@@ -184,15 +239,21 @@ if [ "$gpu_mode" = "true" ]; then
   compose_file="dev_humble_gpu"
 fi
 if [ "$nvidia" = "true" ]; then
-  compose_file="dev_humble_nvidia"
+  if [ "$engine" = "podman" ]; then
+    compose_file="dev_humble_podman_nvidia"
+  else
+    compose_file="dev_humble_nvidia"
+  fi
 fi
 cp compose_cfg/$compose_file.yaml docker-compose.yaml
 
-# Proceed with docker-compose commands
-if [ "$nvidia" = "true" ]; then
-  docker compose --compatibility up
+# Proceed with compose commands (--compatibility only applies to docker nvidia)
+if [ "$engine" = "podman" ]; then
+  $compose_cmd up
+elif [ "$nvidia" = "true" ]; then
+  $compose_cmd --compatibility up
 else
-  docker compose up
-fi 
+  $compose_cmd up
+fi
 
 cleanup

--- a/scripts/run_academy.sh
+++ b/scripts/run_academy.sh
@@ -2,6 +2,7 @@
 # Default: cpu and offline
 gpu_mode="false"
 nvidia="false"
+engine="docker"
 base_path_offline="compose_cfg/"
 compose_file="user_humble_cpu"
 base_path_online="https://raw.githubusercontent.com/JdeRobot/RoboticsAcademy/humble-devel/compose_cfg/"
@@ -13,21 +14,26 @@ show_help() {
   echo "Options:"
   echo "  -g  Enable GPU mode (uses user_humble_gpu compose file)"
   echo "  -n  Enable Nvidia support (uses user_humble_nvidia compose file)"
+  echo "  -p  Use rootless Podman instead of Docker (requires -n for GPU)"
   echo "  -h  Display this help message"
   echo ""
   echo "Examples:"
   echo "  $(basename "$0")          # Run in CPU mode (default)"
   echo "  $(basename "$0") -g       # Run in GPU mode"
   echo "  $(basename "$0") -n       # Run with Nvidia support"
+  echo "  $(basename "$0") -p -n    # Run with rootless Podman and Nvidia"
 }
 
 # Function to clean up the containers
 cleanup() {
   echo "Cleaning up..."
-  if [ "$nvidia" = "true" ]; then
-    docker compose --compatibility down
+  if [ "$engine" = "podman" ]; then
+    # Silence the errors for containers podman-compose already removed
+    $compose_cmd down 2>/dev/null
+  elif [ "$nvidia" = "true" ]; then
+    $compose_cmd --compatibility down
   else
-    docker compose down
+    $compose_cmd down
   fi
   if [ -f docker-compose.yaml ]; then
     rm docker-compose.yaml
@@ -37,6 +43,42 @@ cleanup() {
 
 # Preflight checks
 preflight_checks() {
+  # Podman checks: rootless, binaries and CDI spec
+  if [ "$engine" = "podman" ]; then
+    if [ "$(id -u)" -eq 0 ]; then
+      echo "Error: Rootless Podman must be run without sudo. Execute the script as a standard user."
+      exit 1
+    fi
+
+    for binary in podman podman-compose; do
+      if ! command -v "$binary" &> /dev/null; then
+        echo "Error: $binary is not installed or not in PATH."
+        echo "See: https://podman.io/docs/installation"
+        exit 1
+      fi
+    done
+
+    if [ "$gpu_mode" = "true" ]; then
+      echo "Error: Podman GPU acceleration requires NVIDIA CDI. Use -p -n instead of -p -g."
+      exit 1
+    fi
+
+    # A CDI spec is needed to resolve the nvidia.com/gpu device
+    if [ "$nvidia" = "true" ]; then
+      if ! compgen -G "/var/run/cdi/*.yaml" > /dev/null && \
+         ! compgen -G "/var/run/cdi/*.json" > /dev/null && \
+         ! compgen -G "/etc/cdi/*.yaml"     > /dev/null && \
+         ! compgen -G "/etc/cdi/*.json"     > /dev/null; then
+        echo "Error: No CDI spec found in /var/run/cdi or /etc/cdi."
+        echo "Generate one with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+        exit 1
+      fi
+    fi
+
+    # Podman has no daemon, skip the docker checks
+    return
+  fi
+
   if ! command -v docker &> /dev/null; then
     echo "Error: Docker is not installed or not in PATH. Please install Docker first."
     echo "See: https://docs.docker.com/engine/install/"
@@ -56,14 +98,22 @@ preflight_checks() {
 }
 
 # Loop through the arguments
-while getopts ":gnh" opt; do
+while getopts ":gnhp" opt; do
   case $opt in
     g) gpu_mode="true" ;;
     n) nvidia="true" ;;
+    p) engine="podman" ;;
     h) show_help; exit 0 ;;
     \?) echo "Error: Invalid option: -$OPTARG" >&2; show_help; exit 1 ;;
   esac
 done
+
+# Set the compose command based on the engine
+if [ "$engine" = "podman" ]; then
+  compose_cmd="podman-compose -p roboticsacademy"
+else
+  compose_cmd="docker compose"
+fi
 
 # Run preflight checks before doing anything else
 preflight_checks
@@ -76,7 +126,11 @@ if [ "$gpu_mode" = "true" ]; then
   compose_file="user_humble_gpu"
 fi
 if [ "$nvidia" = "true" ]; then
-  compose_file="user_humble_nvidia"
+  if [ "$engine" = "podman" ]; then
+    compose_file="user_humble_podman_nvidia"
+  else
+    compose_file="user_humble_nvidia"
+  fi
 fi
 
 # Check the mode (offline if compose_cfg dir exists, online otherwise)
@@ -97,11 +151,13 @@ else
   fi
 fi
 
-# Execute docker compose
-if [ "$nvidia" = "true" ]; then
-  docker compose --compatibility up
+# Execute compose (--compatibility only applies to the docker nvidia config)
+if [ "$engine" = "podman" ]; then
+  $compose_cmd up
+elif [ "$nvidia" = "true" ]; then
+  $compose_cmd --compatibility up
 else
-  docker compose up
+  $compose_cmd up
 fi
 
 cleanup


### PR DESCRIPTION
Adds a `-p` flag to `scripts/develop_academy.sh` and
`scripts/run_academy.sh` to run the stack under rootless Podman
instead of Docker. With `-p` the scripts build their compose command
as `podman-compose -p roboticsacademy` rather than `docker compose`,
and select a Podman-specific compose file when `-n` is also given.
The rest of the flow is unchanged — the chosen file is still copied
to `docker-compose.yaml` and the same up/down commands run against
it.

**Depends on #3959**, which adds the two compose files `-p -n`
selects. `-p` alone needs nothing new: the shared CPU configs declare
no `runtime:`, no `deploy:` reservations and no `NVIDIA_*` variables,
so Podman runs them unchanged.

Without `-p` the scripts behave exactly as before, `--compatibility`
included. It is deliberately not passed on the Podman path, since
podman-compose does not accept it.

`-p` adds preflight checks: refuse to run as root (sudo would
silently switch to Podman's rootful store), require `podman` and
`podman-compose` on PATH, and with `-n` require a CDI spec in
`/var/run/cdi` or `/etc/cdi`. `-p -g` is rejected — Intel/AMD
passthrough is out of scope and has no Podman compose file, so `-p -n`
and plain `-p` are the supported combinations.

NVIDIA acceleration on Podman 4.x also needs the CDI spec generated
with `--feature-flag no-additional-gids-for-device-nodes`. That is
host setup and is covered in the docs PR.

Tested on Ubuntu 24.04: Podman 4.9.3, podman-compose 1.0.6, crun
1.14.1, NVIDIA 580.173.02, GTX 1650. `-p -n` brings the stack up with
`nvidia-smi` and `/dev/dri` present inside the container.

**Known issue, not addressed here.** Ctrl+C does not stop the stack on
that pair. podman-compose 1.0.6 doesn't exit on SIGINT, and bash
defers the trap until the foreground child returns, so `cleanup()` is
never reached. Stopping needs `podman-compose -p roboticsacademy down`
from a second terminal. This
is upstream podman-compose behaviour, not something these scripts
cause; the docs PR covers it.