### PR TITLE
Add Podman documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Take a look at the [contributing](CONTRIBUTING.md) guidelines.
 ## Development resources
 
 - [Instructions for developers.][]
+- [Using Podman.][]
 - [Coding Style Guide][]
 - [Client side.][] (Robotics Academy architecture) **Obsolete**
 - [Repository Architecture.][]
@@ -30,6 +31,7 @@ Take a look at the [contributing](CONTRIBUTING.md) guidelines.
 - [Exercises Status][]
 
 [Instructions for developers.]: ./docs/InstructionsForDevelopers.md
+[Using Podman.]: ./docs/InstructionsForDevelopers_podman.md
 [Coding Style Guide]: ./docs/coding_style_guide.md
 [Client side.]: ./docs/clientside.md
 [Repository Architecture.]: ./docs/RepositoryArchitecture.md

--- a/docs/InstructionsForDevelopers.md
+++ b/docs/InstructionsForDevelopers.md
@@ -9,6 +9,7 @@
 - [How to setup the developer environment](#How-to-setup-the-developer-environment)
   - [Developer environment set up via script _(recommended set up)_](#automatic-script)
   - [Developer environment set up via docker-compose _(recommended set up for **Windows Users**)_](#docker-compose)
+  - [Developer environment set up via Podman _(rootless, **Linux only**)_](./InstructionsForDevelopers_podman.md)
 - [How to use nvidia](#How-to-use-nvidia)
 - [How to execute the tests](#How-to-execute-the-tests)
 - [How to add a new exercise](#How-to-add-a-new-exercise)

--- a/docs/InstructionsForDevelopers_podman.md
+++ b/docs/InstructionsForDevelopers_podman.md
@@ -1,0 +1,147 @@
+### [Back to main README.][]
+
+[Back to main README.]: ../README.md
+
+# Using Podman (rootless alternative to Docker)
+
+Podman runs containers without a daemon and without root. It is an alternative to the Docker setup, not a replacement.
+
+This setup works on Linux only. Windows and macOS users should use Docker.
+
+Run these commands from the repository root.
+
+**Requirements:** Ubuntu 24.04, and an NVIDIA GPU if you want GPU acceleration. Other Linux distributions should work, but the package versions below are Ubuntu 24.04's.
+
+**Important:** never run `podman` or `podman-compose` under `sudo`. Rootless operation is the point of this setup, and `sudo` switches to a separate root-owned container store. Both launcher scripts refuse to run as root.
+
+## Install Podman
+
+```
+sudo apt install podman podman-compose
+```
+
+That is the whole installation. The three packages Ubuntu 24.04 ships (Podman 4.9.3, podman-compose 1.0.6 and crun 1.14.1) work together. You do not need a PPA, a pip install, or any OCI-runtime changes.
+
+Confirm:
+
+```
+podman --version
+podman-compose --version
+```
+
+**_NOTE_**: If you have installed a newer Podman by other means (Homebrew, a PPA, a static build), `podman-compose` 1.0.6 is **not** compatible with Podman 6.x. It fails with `cannot index slice/array with type string`. Either keep the matched `apt` pair, or upgrade both together.
+
+## NVIDIA GPU setup (optional)
+
+Skip this section if you only need CPU rendering.
+
+Install the NVIDIA proprietary driver and the NVIDIA Container Toolkit following their official documentation.
+
+You must generate the CDI specification yourself; the launcher scripts only check that one exists and stop with instructions if it does not.
+
+### Generate a compatible CDI specification
+
+Current toolkit versions emit a CDI specification containing an `additionalGids` field, which requires CDI schema v0.7.0. Podman 4.9.3 cannot parse it. It rejects the entire specification and reports no GPU devices, with `json: unknown field "additionalGids"`. Generate the specification without that field. The result is a v0.5.0 schema that Podman 4.9.3 reads correctly.
+
+**If `/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env` exists**, a service regenerates the specification automatically after driver updates. Set the flag there so it survives those regenerations, and let the service own the file:
+
+```
+echo 'NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS=no-additional-gids-for-device-nodes' \
+  | sudo tee -a /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
+sudo systemctl restart nvidia-cdi-refresh.service
+```
+
+Do **not** also generate a specification into `/etc/cdi` on these systems. Podman searches both `/etc/cdi` and `/var/run/cdi`, and two specifications declaring the same devices will drift apart after the next driver update.
+
+**If that file does not exist**, generate the specification yourself. Re-run this after every driver upgrade:
+
+```
+sudo nvidia-ctk cdi generate \
+  --feature-flag no-additional-gids-for-device-nodes \
+  --output=/etc/cdi/nvidia.yaml
+```
+
+Either way, confirm the schema version:
+
+```
+grep -m1 cdiVersion /etc/cdi/nvidia.yaml /var/run/cdi/nvidia.yaml 2>/dev/null
+# expect: cdiVersion: 0.5.0
+```
+
+### Join the video and render groups
+
+```
+sudo usermod -aG video,render "$USER"
+```
+
+Log out and back in for this to take effect.
+
+The flag above removes the mechanism that would otherwise give the container access to the render node, so this step is required. On a desktop your login session may mask the problem by granting temporary device access; that will not exist on a server or after a reboot into a different session.
+
+### Test the GPU before launching
+
+```
+podman run --rm --device nvidia.com/gpu=all ubuntu nvidia-smi
+```
+
+This must exit cleanly and print your GPU. If it fails here, no compose configuration will fix it.
+
+You do not need to bind-mount `/dev/dri`. CDI injects the render nodes.
+
+## Launch the stack
+
+Pass `-p` to the existing launcher scripts. You do not select a compose file yourself; the script picks one and copies it to `docker-compose.yaml`.
+
+| Command                              | Mode        | Acceleration | Compose file used                |
+| ------------------------------------ | ----------- | ------------ | -------------------------------- |
+| `./scripts/develop_academy.sh -p -n` | Development | NVIDIA       | `dev_humble_podman_nvidia.yaml`  |
+| `./scripts/develop_academy.sh -p`    | Development | CPU          | `dev_humble_cpu.yaml`            |
+| `./scripts/run_academy.sh -p -n`     | User        | NVIDIA       | `user_humble_podman_nvidia.yaml` |
+| `./scripts/run_academy.sh -p`        | User        | CPU          | `user_humble_cpu.yaml`           |
+
+The CPU path uses the shared Docker CPU configuration. Those files declare no `runtime:`, no `deploy:` reservations and no `NVIDIA_*` variables, so Podman runs them unchanged.
+
+The scripts reject `-p -g` with an error. Intel and AMD passthrough is not available on the Podman path. The Docker `-g` path bind-mounts `/dev/dri` directly, which under rootless Podman depends on host device permissions the project cannot assume, and no Podman compose configuration exists for it. Use `-p -n` for NVIDIA or `-p` for CPU.
+
+The script runs `podman-compose -p roboticsacademy up`. It does not pass the `--compatibility` flag used by the Docker NVIDIA path.
+
+Before launching, make sure you are not running as root, that `podman` and `podman-compose` are on `PATH`, and, when using `-n`, that a CDI specification exists in `/var/run/cdi` or `/etc/cdi`.
+
+Then open [http://localhost:7164/](http://localhost:7164/).
+
+**_NOTE_**: On SELinux hosts (Fedora, RHEL, CentOS Stream), `develop_academy.sh -p` bind-mounts the repository into the container, and the shared CPU compose file carries no SELinux label directive, so expect permission denials on those mounts. The NVIDIA Podman files are unaffected, and so is `run_academy.sh -p`, which mounts nothing.
+
+**_NOTE_**: `scripts/radi_monitor/` does not work under Podman. It shells out to `docker stats`, `docker exec` and `docker ps`.
+
+## Verifying GPU acceleration worked
+
+Two independent checks:
+
+1. The exercise Status Bar in the browser reads `GPU: NVIDIA`. This comes from the render device detected inside the container; `GPU: OFF` means none was found.
+2. Inside the container, `vglrun glxinfo` reports your GPU rather than `llvmpipe`.
+
+## Stopping the stack
+
+Ctrl+C does not stop the stack. Stop it explicitly from a second terminal:
+
+```
+podman-compose -p roboticsacademy down
+```
+
+## Migrating from an existing Docker setup
+
+Podman keeps its own image store. Images built or pulled under Docker are not visible to Podman. Re-pull them.
+
+Exercise workspace files left behind by earlier runs can block autosave. The symptom is an "Error saving file" popup with no message: the file content writes successfully, but the permission reset afterwards fails with `EPERM`. The fix depends on which engine created the files.
+
+Files from earlier **rootful Docker** runs are owned by real root:
+
+```
+sudo chown -R "$(id -u):$(id -g)" .
+```
+
+Files from earlier **rootless Podman** runs are owned by a mapped subordinate UID, which plain `chown` cannot reach:
+
+```
+podman unshare chown -R 0:0 filesystem/
+```

--- a/docs/gpu_acceleration.md
+++ b/docs/gpu_acceleration.md
@@ -26,6 +26,8 @@ For NVIDIA GPUs, acceleration can be achieved by [installing the nvidia-containe
 docker run --rm -it --gpus all --device /dev/dri -p 7164:7164 -p 6080-6090:6080-6090 -p 7163:7163 --link academy_db jderobot/robotics-academy:latest
 ```
 
+For rootless Podman, see [Using Podman](./InstructionsForDevelopers_podman.md).
+
 ## Windows
 For Windows machines, acceleration can be achieved for NVIDIA GPUs if a valid CUDA installation is available. Useful docs for proper installation of WSL2 + CUDA + Docker Desktop:
 - [WSL2 + CUDA](https://learn.microsoft.com/en-us/windows/ai/directml/gpu-cuda-in-wsl)


### PR DESCRIPTION
Depends on #3959 and #3960.

Documents the rootless Podman path for running Robotics Academy on Linux. **Documentation only**, no code, script or compose changes. This PR documents the `-p` flag and the Podman compose configurations those two PRs add; it should not merge before them.

## What this adds

The Podman instructions are a standalone document, linked from the three places a reader might start:

- **`docs/InstructionsForDevelopers_podman.md`** (new, 147 lines). The whole Podman path in one document: requirements, installation, NVIDIA CDI setup, launching via `-p`, verifying GPU acceleration, stopping the stack, and migrating from an existing Docker setup. Follows the conventions of a standalone doc in this repo: reference-style "Back to main README." header, bare code fences, `**_NOTE_**:` and `**Important:**` note forms.
- **`docs/InstructionsForDevelopers.md`**. One table-of-contents line, in the same position and the same phrasing shape as its two siblings, pointing at the new file instead of an in-page anchor. Nothing else in the file changes.
- **`docs/gpu_acceleration.md`**. One pointer line at the end of `## Linux`, after the NVIDIA entry and before `## Windows`. Nothing else in the file changes.
- **`README.md`**. An entry in the Development resources index and its reference definition, directly after "Instructions for developers."

Two commits: one adding the document, one linking it from the existing docs.

## Tested

Tested on Ubuntu 24.04: Podman 4.9.3, podman-compose 1.0.6, crun 1.14.1 (all from `apt`), NVIDIA driver 580.173.02, GTX 1650. The `-p -n` path was run end to end on that setup: stack up, exercise loaded, GPU confirmed in the container.

These instructions cover Linux.

Two things are not yet verified, which is why this is a draft:

- The install steps have only been run on a machine that already had Podman and the CDI spec in place. A clean-host run following these instructions from the top is still to do.
- The CPU path (`-p` without `-n`) has not been run.

## What this does not change

- **No existing Docker instruction, flag or example is modified.** The Podman content is purely additive; every Docker command, `docker-compose` step and `docker run` invocation is byte-identical to `humble-devel`.
- No code, script, `Dockerfile` or compose file is touched.
- `docs/troubleshooting.md` is unchanged.
- The three existing files gain five lines between them and lose none.
- The `RoboticsInfrastructure` submodule pointer is not committed.
- Intel and AMD GPU acceleration on the Podman path is **not** documented as working. It is explicitly unavailable, and `-p -g` is rejected by the scripts.

## Why the teardown is manual

Ctrl+C does not stop the stack under Podman. podman-compose 1.0.6 doesn't exit on SIGINT, and bash defers the trap until the foreground child returns, so `cleanup()` is never reached. The docs say to run `podman-compose -p roboticsacademy down` from a second terminal. This is upstream podman-compose behaviour; #3960 doesn't try to work around it.

## Deliberate divergence from the Docker sections

The Podman document says **"Run these commands from the repository root."** The Docker sections in `InstructionsForDevelopers.md` state this nowhere. The working directory is established only implicitly, by a `cd RoboticsAcademy/` buried in the clone step's code block (`docs/InstructionsForDevelopers.md:115`), and never restated before `cp compose_cfg/... docker-compose.yaml` or `docker-compose up`.

The line was added because the Podman document has no clone step of its own, so a reader entering there never passes a `cd`. The failure mode is bad: `develop_academy.sh` clones RoboticsApplicationManager, installs nvm/yarn and starts a frontend build before dying at `cd common` (`scripts/develop_academy.sh:186`). Every path in both scripts is CWD-relative; neither resolves against its own location. `scripts/run_academy.sh:148` already states the requirement, but only inside an error message.

Happy to drop the line if maintainers prefer strict symmetry with the Docker sections.

## Open question

The "repository root" precondition is stated unconditionally, but `run_academy.sh` has an online fallback: if `compose_cfg/` is absent it fetches the compose file over HTTP (`scripts/run_academy.sh:137-152`), so that script alone can run from elsewhere. The precondition is strictly correct for `develop_academy.sh` and for offline use. Left unqualified for brevity.
