### PR TITLE
Fix resume functionality for Deep Learning exercises (#3926)

### DIFF
--- a/react_frontend/src/components/buttons/PlayPause.tsx
+++ b/react_frontend/src/components/buttons/PlayPause.tsx
@@ -96,14 +96,20 @@ const PlayPauseButton = ({
   };
 
   const compareZips = async (zip1: JSZip, zip2: JSZip) => {
-    for (const key in zip1.files) {
-      if (!Object.hasOwn(zip1.files, key)) continue;
+    const keys1 = Object.keys(zip1.files);
+    const keys2 = Object.keys(zip2.files);
+    if (keys1.length !== keys2.length) return false;
+
+    for (const key of keys1) {
       if (!Object.hasOwn(zip2.files, key)) {
         return false;
       }
 
-      const value = await zip1.files[key]._data;
-      const old = await zip2.files[key]._data;
+      if (zip1.files[key].dir && zip2.files[key].dir) continue;
+      if (zip1.files[key].dir !== zip2.files[key].dir) return false;
+
+      const value = await zip1.files[key].async("base64");
+      const old = await zip2.files[key].async("base64");
       if (value !== old) {
         return false;
       }
@@ -280,7 +286,7 @@ const PlayPauseButton = ({
 
       await zipCodeFiles(zip, files, project, user);
 
-      zip.files[entrypoint.path]._data.then(
+      zip.files[entrypoint.path].async("string").then(
         (value: string) => (runningContentRef.current = value),
       );
       return zip;


### PR DESCRIPTION
Closes #3926

### Description
When attempting to resume a paused Deep Learning exercise (or any exercise containing binary model files such as `.onnx`, `.pth`, or `.h5`), RoboticsAcademy would fail to resume and instead force a full container re-run and re-upload of the model file.

### Root Cause
In `PlayPause.tsx`, `compareZips` inspected internal `zip1.files[key]._data` property directly. For binary files, JSZip stores `_data` as typed arrays (`Uint8Array`). In JavaScript, comparing object references (`value !== old`) always evaluates to `true` (inequal), falsely indicating that files were modified every single time.

### Fix
1. Updated `compareZips` in `PlayPause.tsx` to retrieve file content using JSZip's standard public `async("base64")` API instead of private `_data` references. This guarantees accurate byte content equality checks for both binary and text files.
2. Replaced private `_data` promise in `loadFiles` with the standard `async("string")` API.

### How Has This Been Tested?
1. Launched an exercise with binary/model files.
2. Clicked **Play** $\rightarrow$ **Pause**.
3. Clicked **Play** (Resume) without editing files $\rightarrow$ App resumed cleanly (`manager.resume()` called, console logged `App resumed correctly!`).
4. Modified code while paused and clicked **Play** $\rightarrow$ Detected changes accurately and re-ran the application.
