### PR TITLE
feat: add Windows Podman GPU compose configuration

### DIFF
--- a/compose_cfg/dev_humble_windows_podman_gpu.yaml
+++ b/compose_cfg/dev_humble_windows_podman_gpu.yaml
@@ -1,0 +1,69 @@
+# Windows WSL2 + Rootless Podman + NVIDIA via CDI.
+# Exposes WSL2 libraries and /dev/dxg for the Mesa D3D12 backend.
+
+services:
+  my-postgres:
+    image: jderobot/robotics-database:latest
+    container_name: world_db
+    networks:
+      - db_network
+    environment:
+      POSTGRES_DB: academy_db
+      POSTGRES_USER: user-dev
+      POSTGRES_PASSWORD: robotics-academy-dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./RoboticsInfrastructure/database/worlds.sql:/docker-entrypoint-initdb.d/1.sql
+      - ./database/exercises/db.sql:/docker-entrypoint-initdb.d/2.sql
+      - ./database/django_auth.sql:/docker-entrypoint-initdb.d/3.sql
+    healthcheck:
+      test: pg_isready -U user-dev -d academy_db
+      interval: 3s
+      timeout: 1s
+      retries: 20
+
+  robotics-academy:
+    image: jderobot/robotics-academy:latest
+    container_name: developer-container
+    networks:
+      - db_network
+    command: "-s"
+    # CDI injects the NVIDIA GPU via /dev/dxg.
+    # The WSL2 D3D12 rendering path requires no /dev/dri or VirtualGL.
+    devices:
+      - "nvidia.com/gpu=all"
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    # Needed on SELinux hosts, no-op elsewhere.
+    security_opt:
+      - label=disable
+    ports:
+      - "7164:7164"
+      - "7163:7163"
+      - "6080-6090:6080-6090"
+    volumes:
+      - type: bind
+        source: ./
+        target: /RoboticsAcademy
+      - type: bind
+        source: ./src
+        target: /RoboticsApplicationManager
+      - ./RoboticsInfrastructure/database/worlds.sql:/worlds.sql
+      - wsl_lib:/usr/lib/wsl/lib:ro
+    tty: true
+    stdin_open: true
+    depends_on:
+      my-postgres:
+        condition: service_healthy
+
+networks:
+  db_network:
+
+volumes:
+  wsl_lib:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /usr/lib/wsl/lib


### PR DESCRIPTION
## Summary

Adds a Windows + WSL2 configuration for running the RoboticsAcademy GPU development stack with rootless Podman.

## Why

The existing Podman GPU configuration targets the native Linux GPU/DRM environment. Under Windows + WSL2, the GPU is exposed through `/dev/dxg` and the Mesa D3D12 graphics path.

The WSL2 graphics libraries also need to be exposed from the Podman machine without being interpreted as Windows host paths.

## Changes

- Added `compose_cfg/dev_humble_windows_podman_gpu.yaml`.
- Reuses the existing NVIDIA CDI GPU configuration.
- Adds a rootless Podman local named volume for `/usr/lib/wsl/lib`.
- Keeps the existing Linux Podman GPU configuration unchanged.

## Validation

The Windows + WSL2 GPU path has been validated at the container graphics level:

- NVIDIA CDI passthrough works with rootless Podman.
- NVIDIA GeForce GTX 1650 is visible inside the container.
- Mesa D3D12 hardware OpenGL reports:
  `D3D12 (NVIDIA GeForce GTX 1650)`
- OpenGL reports `Accelerated: yes`.

End-to-end RoboticsAcademy exercise validation is still in progress.

## Related

Related to #3961, which contains the corresponding Podman documentation updates.