### PR TITLE
dev-compose: add PYTHONPATH so the bind-mounted RAM package wins

### DIFF
--- a/compose_cfg/dev_humble_cpu.yaml
+++ b/compose_cfg/dev_humble_cpu.yaml
@@ -26,6 +26,8 @@ services:
     networks:
       - db_network
     command: "-s"
+    environment:
+      PYTHONPATH: /RoboticsApplicationManager:/opt/ros/humble/lib/python3.10/site-packages
     ports:
       - "7164:7164"
       - "7163:7163"


### PR DESCRIPTION
Without this, 'import robotics_application_manager' inside developer-container resolves to the older pip-installed release baked into the image (5.6.14) instead of the bind-mounted ./src checkout, so changes made in the RAM dev repo are silently ignored at runtime.